### PR TITLE
fix(ci): pass BUILD_VERSION as string to avoid float formatting issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build & Package NRF Firmware
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
           pio run --environment nrf52840custom 
           mkdir firmware_output
           cp .pio/build/nrf52840custom/firmware.hex firmware_output/NRF52840.hex
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build & Package esp32-s3-N16R8 Firmware
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
           pioenv=esp32-s3-N16R8
           pio run --environment ${pioenv}
           mkdir ${pioenv}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build & Package esp32-s3-N8R8 Firmware
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
           pioenv=esp32-s3-N8R8
           pio run --environment ${pioenv}
           mkdir ${pioenv}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build & Package esp32-s3-N32R8 Firmware
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
           pioenv=esp32-s3-N32R8
           pio run --environment ${pioenv}
           mkdir ${pioenv}
@@ -84,7 +84,7 @@ jobs:
           
       - name: Build & Package esp32-c6-N4 Firmware
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
           pioenv=esp32-c6-N4
           pio run --environment ${pioenv}
           mkdir ${pioenv}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build & Package esp32-c3-N4 Firmware
         run: |
-          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=${{ github.ref_name }} -D SHA=$GITHUB_SHA"
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
           pioenv=esp32-c3-N4
           pio run --environment ${pioenv}
           mkdir ${pioenv}


### PR DESCRIPTION
`BUILD_VERSION` was interpreted as a float instead of a string when injected via CI build flags before.

This caused values like `1.1` to be treated as a floating-point literal (`1.1`) rather than a string (`"1.1"`). When converted using `String(BUILD_VERSION)`, this then resulted in incorrect version formatting (e.g. `"1.10"`). It's used in `getFirmwareMajor` and `getFirmwareMinor`.

https://github.com/OpenDisplay/Firmware/blob/b04a22b21dfc74ee287d84491fba474afcca1eb5/src/main.cpp#L573-L580

https://github.com/OpenDisplay/Firmware/blob/b04a22b21dfc74ee287d84491fba474afcca1eb5/src/main.cpp#L582-L589
