### PR TITLE
Add panel mapping for GDEM133T91 13.3" 960x680 (SSD1677)

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -186,6 +186,7 @@ int mapEpd(int id){
         case 0x003F: return EP31_240x320;
         case 0x0040: return EP75YR_800x480;
         case 0x0041: return EP_PANEL_UNDEFINED;
+        case 0x0049: return GDEM133T91_960x680;
         default: return EP_PANEL_UNDEFINED;
     }
 }

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -186,7 +186,7 @@ int mapEpd(int id){
         case 0x003F: return EP31_240x320;
         case 0x0040: return EP75YR_800x480;
         case 0x0041: return EP_PANEL_UNDEFINED;
-        case 0x0049: return GDEM133T91_960x680;
+        case 0x0042: return GDEM133T91_960x680;
         default: return EP_PANEL_UNDEFINED;
     }
 }

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -186,7 +186,7 @@ int mapEpd(int id){
         case 0x003F: return EP31_240x320;
         case 0x0040: return EP75YR_800x480;
         case 0x0041: return EP_PANEL_UNDEFINED;
-        case 0x0042: return GDEM133T91_960x680;
+        case 0x0042: return EP133_960x680;
         default: return EP_PANEL_UNDEFINED;
     }
 }


### PR DESCRIPTION
## Summary

- Maps protocol ID `0x0042` (66) to `GDEM133T91_960x680` in `mapEpd()`
- Enables support for the Waveshare 13.3inch-e-Paper-HAT-K (GDEM133T91, 960×680, SSD1677)
- Depends on bb_epaper PR: https://github.com/bitbank2/bb_epaper/pull/29

## Test plan

- [x] Configure device with `panel_ic_type = 0x0042`, verify full refresh clears cleanly across all 960×680 pixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)