### PR TITLE
fix: move WiFi handling after BLE command queue processing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,22 +113,6 @@ void setup() {
 void loop() {
     processLedFlash();
     #ifdef TARGET_ESP32
-    handleWiFiServer();
-    static uint32_t lastWiFiCheck = 0;
-    if (wifiInitialized && (millis() - lastWiFiCheck > 10000)) {
-        lastWiFiCheck = millis();
-        if (WiFi.status() != WL_CONNECTED && wifiConnected) {
-            writeSerial("WiFi connection lost (status: " + String(WiFi.status()) + ")");
-            wifiConnected = false;
-            if (wifiServerConnected) {
-                disconnectWiFiServer();
-            }
-        } else if (WiFi.status() == WL_CONNECTED && !wifiConnected) {
-            writeSerial("WiFi reconnected (IP: " + WiFi.localIP().toString() + ")");
-            wifiConnected = true;
-            restartWiFiLanAfterReconnect();
-        }
-    }
     if (woke_from_deep_sleep && advertising_timeout_active) {
         if (pServer && pServer->getConnectedCount() > 0) {
             writeSerial("BLE connection established - switching to full mode");
@@ -177,6 +161,24 @@ void loop() {
         if (directWriteDuration > 900000UL) {  // 15 minute timeout (upload + refresh window)
             writeSerial("ERROR: Direct write timeout (" + String(directWriteDuration) + " ms) - cleaning up stuck state");
             cleanupDirectWriteState(true);
+        }
+    }
+    // WiFi handling runs after BLE queue processing to avoid blocking
+    // BLE command responses (moved from top of loop in v1.6 fix).
+    handleWiFiServer();
+    static uint32_t lastWiFiCheck = 0;
+    if (wifiInitialized && (millis() - lastWiFiCheck > 10000)) {
+        lastWiFiCheck = millis();
+        if (WiFi.status() != WL_CONNECTED && wifiConnected) {
+            writeSerial("WiFi connection lost (status: " + String(WiFi.status()) + ")");
+            wifiConnected = false;
+            if (wifiServerConnected) {
+                disconnectWiFiServer();
+            }
+        } else if (WiFi.status() == WL_CONNECTED && !wifiConnected) {
+            writeSerial("WiFi reconnected (IP: " + WiFi.localIP().toString() + ")");
+            wifiConnected = true;
+            restartWiFiLanAfterReconnect();
         }
     }
     #ifdef TARGET_ESP32


### PR DESCRIPTION
## Problem

In v1.6, `handleWiFiServer()` and the WiFi reconnection check were moved to the top of `loop()`, before BLE command/response queue processing. This can cause BLE commands to sit unprocessed in the queue when `handleWiFiServer()` blocks or takes a slow path, resulting in BLE timeouts for clients.

## Symptoms observed on EE04 (ESP32-S3) + 7.3" Spectra 6

- BLE READ CONFIG commands queued but never dequeued
- `ESP32: Command queued for processing` appears in serial log but `ESP32: Processing queued command` never follows
- Home Assistant OpenDisplay integration fails with `ble_timeout` during device interrogation
- py-opendisplay image uploads and config reads timeout after 10s
- Downgrading to v1.3 immediately resolves all issues

## Fix

Move `handleWiFiServer()` and WiFi reconnection check to **after** the BLE command queue drain and response notification loop, restoring the v1.3 execution order where BLE is always serviced first. WiFi functionality is unchanged — only the ordering within the loop changes.

## Testing

- Built and flashed on Seeed EE04 (XIAO ESP32-S3) with 7.3" Spectra 6 Color display
- Verified BLE config reads work (py-opendisplay `info` command)
- Verified BLE image uploads work (py-opendisplay `upload` command)
- Verified Home Assistant OpenDisplay integration v2.0.2 connects and interrogates successfully via ESP32 BLE Proxy
- Verified encryption (AES-128) works correctly
- All operations that timed out on unpatched v1.6 now succeed

Co-Authored-By: Oz <oz-agent@warp.dev>