### PR TITLE
fix: Explicitly add CCCD descriptor and add esp32-wrover build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -148,11 +148,26 @@ monitor_speed = 115200
 [env:esp32-N4]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
 framework = arduino
-build_flags = 
+build_flags =
   -DTARGET_ESP32
   -DCONFIG_FREERTOS_WATCHDOG_TIMEOUT_S=120
 board_build.filesystem = littlefs
 board = esp32dev
+board_build.partitions = huge_app.csv
+monitor_speed = 115200
+lib_ignore = Seeed_GFX
+
+[env:esp32-N4R8]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+framework = arduino
+build_flags =
+  -DTARGET_ESP32
+  -DTARGET_LARGE_MEMORY
+  -DBOARD_HAS_PSRAM
+  -mfix-esp32-psram-cache-issue
+  -DCONFIG_FREERTOS_WATCHDOG_TIMEOUT_S=120
+board_build.filesystem = littlefs
+board = esp-wrover-kit
 board_build.partitions = huge_app.csv
 monitor_speed = 115200
 lib_ignore = Seeed_GFX

--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -24,6 +24,7 @@ void writeSerial(String message, bool newLine = true);
 #include <BLEServer.h>
 #include <BLEUtils.h>
 #include <BLEAdvertising.h>
+#include <BLE2902.h>
 
 String getChipIdHex();
 void writeSerial(String message, bool newLine = true);
@@ -149,6 +150,7 @@ void ble_init_esp32(bool update_manufacturer_data) {
         return;
     }
     writeSerial("Characteristic created with properties: READ, NOTIFY, WRITE, WRITE_NR");
+    pTxCharacteristic->addDescriptor(new BLE2902());
     pTxCharacteristic->setCallbacks(&staticCharCallbacks);
     pRxCharacteristic = pTxCharacteristic;
     pService->start();


### PR DESCRIPTION
When testing on a base esp32 e-paper board (Inkplate 6COLOR), I had a `LoadProhibited` crash whenever `BLEDevice::init(deviceName.c_str());` was called. This was fixed with using the esp32-wrover-kit build instead of the base one.

Next, there was a `GATT Error - not supported` whenever trying to communicate via bluetooth. It seems that the base esp32 does not include it automatically. Including the BLE2902 library and initialized it fixed the problem

These changes should work on all esp32 boards and make implementations easier to do.