### PR TITLE
Add XTEINK X4 (ESP32-C3) board support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,3 +27,7 @@ jobs:
       - name: Build ESP32 firmware
         run: |
           platformio run --environment esp32-s3-N16R8
+
+      - name: Build XTEINK X4 firmware
+        run: |
+          platformio run --environment esp32-c3-x4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,6 @@ jobs:
         run: |
           platformio run --environment esp32-s3-N16R8
 
-      - name: Build XTEINK X4 firmware
+      - name: Build esp32-c3-N16 firmware
         run: |
-          platformio run --environment esp32-c3-x4
+          platformio run --environment esp32-c3-N16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,10 +130,10 @@ jobs:
           cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
           cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
           
-      - name: Build & Package esp32-c3-x4 Firmware
+      - name: Build & Package esp32-c3-N16 Firmware
         run: |
           export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
-          pioenv=esp32-c3-x4
+          pioenv=esp32-c3-N16
           pio run --environment ${pioenv}
           mkdir ${pioenv}
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,22 @@ jobs:
           cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
           cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
           
+      - name: Build & Package esp32-c3-x4 Firmware
+        run: |
+          export PLATFORMIO_BUILD_FLAGS="-D BUILD_VERSION=\"${{ github.ref_name }}\" -D SHA=$GITHUB_SHA"
+          pioenv=esp32-c3-x4
+          pio run --environment ${pioenv}
+          mkdir ${pioenv}
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ${pioenv}/boot_app0.bin
+          cp .pio/build/${pioenv}/firmware.bin ${pioenv}/firmware.bin
+          cp .pio/build/${pioenv}/bootloader.bin ${pioenv}/bootloader.bin
+          cp .pio/build/${pioenv}/partitions.bin ${pioenv}/partitions.bin
+          cd ${pioenv}
+          esptool.py --chip esp32-c3 merge_bin -o merged-firmware.bin --flash_mode dio --flash_freq 80m --flash_size 16MB 0x0000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+          cd ..
+          cp ${pioenv}/firmware.bin firmware_output/${pioenv}.bin
+          cp ${pioenv}/merged-firmware.bin firmware_output/${pioenv}_full.bin
+
       - name: Upload Release Assets
         uses: svenstaro/upload-release-action@v2
         with:

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,16 +118,15 @@ board = esp32-c6-devkitm-1
 monitor_speed = 115200
 lib_ignore = Seeed_GFX
 
-; XTEINK X4: ESP32-C3, 16MB flash, no PSRAM. Its panel is the GDEQ0426T82, which
-; bb_epaper already supports as EP426 — use the existing panel_ic_type 0x27 (B/W)
-; or 0x28 (4-gray). Pins are supplied at runtime in the device config:
-; SCLK=8 MOSI=10 CS=21 DC=4 RST=5 BUSY=6, battery ADC=GPIO0, power/shutdown btn=GPIO3.
-[env:esp32-c3-x4]
+; Generic 16MB ESP32-C3, no PSRAM. All board specifics (panel, pins, and the
+; optional battery latch via DEVICE_FLAG_BATTERY_LATCH) come from the runtime
+; device config. DIO flash mode leaves GPIO12/13 free for general GPIO use
+; (e.g. a battery-latch MOSFET).
+[env:esp32-c3-N16]
 platform = espressif32
 framework = arduino
 build_flags =
   -DTARGET_ESP32
-  -DOPENDISPLAY_XTEINK_X4
   -DARDUINO_USB_MODE=1
   -DARDUINO_USB_CDC_ON_BOOT=1
   -DCONFIG_FREERTOS_WATCHDOG_TIMEOUT_S=120
@@ -135,7 +134,6 @@ board_build.filesystem = littlefs
 board_build.partitions = default_16MB.csv
 board = esp32-c3-devkitm-1
 board_build.flash_size = 16MB
-; DIO leaves GPIO13 (QIO write-protect pin) free for the X4 battery-latch MOSFET.
 board_build.flash_mode = dio
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,6 +118,30 @@ board = esp32-c6-devkitm-1
 monitor_speed = 115200
 lib_ignore = Seeed_GFX
 
+; XTEINK X4: ESP32-C3, 16MB flash, no PSRAM. Its panel is the GDEQ0426T82, which
+; bb_epaper already supports as EP426 — use the existing panel_ic_type 0x27 (B/W)
+; or 0x28 (4-gray). Pins are supplied at runtime in the device config:
+; SCLK=8 MOSI=10 CS=21 DC=4 RST=5 BUSY=6, battery ADC=GPIO0, power/shutdown btn=GPIO3.
+[env:esp32-c3-x4]
+platform = espressif32
+framework = arduino
+build_flags =
+  -DTARGET_ESP32
+  -DOPENDISPLAY_XTEINK_X4
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DCONFIG_FREERTOS_WATCHDOG_TIMEOUT_S=120
+board_build.filesystem = littlefs
+board_build.partitions = default_16MB.csv
+board = esp32-c3-devkitm-1
+board_build.flash_size = 16MB
+; DIO leaves GPIO13 (QIO write-protect pin) free for the X4 battery-latch MOSFET.
+board_build.flash_mode = dio
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+monitor_speed = 115200
+lib_ignore = Seeed_GFX
+
 ; esp32-s3-N16R8 + UART log; Seeed_GFX path when panel_ic_type is 3000 (1bpp) or 3001 (4bpp gray).
 [env:esp32-s3-N16R8-extuart]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -2,6 +2,7 @@
 #include "structs.h"
 #include "encryption_state.h"
 #include "encryption.h"
+#include "power_latch.h"
 #include <Arduino.h>
 #include <string.h>
 
@@ -24,6 +25,7 @@ using namespace Adafruit_LittleFS_Namespace;
 #define DEVICE_FLAG_PWR_PIN (1 << 0)
 #define DEVICE_FLAG_XIAOINIT (1 << 1)
 #define DEVICE_FLAG_WS_PP_INIT (1 << 2)
+#define DEVICE_FLAG_BATTERY_LATCH (1 << 3)
 #endif
 void writeSerial(String message, bool newLine = true);
 
@@ -549,6 +551,7 @@ void printConfigSummary(){
     writeSerial("  XIAOINIT flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_XIAOINIT) ? "enabled" : "disabled"));
     #endif
     writeSerial("  WS_PP_INIT flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_WS_PP_INIT) ? "enabled" : "disabled"));
+    writeSerial("  BATTERY_LATCH flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_BATTERY_LATCH) ? "enabled" : "disabled"));
     writeSerial("Power Pin: " + String(globalConfig.system_config.pwr_pin));
     writeSerial("Power Pin 2: " + String(globalConfig.system_config.pwr_pin_2));
     writeSerial("Power Pin 3: " + String(globalConfig.system_config.pwr_pin_3));
@@ -710,6 +713,8 @@ void full_config_init() {
             ws_pp_init();
             writeSerial("ws_pp_init() completed");
         }
+        // Must run after config load: latch pins/flag come from globalConfig.
+        powerLatchBegin();
     } else {
         writeSerial("Global configuration load failed or no config found");
     }

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -1,6 +1,7 @@
 #include "device_control.h"
 #include "structs.h"
 #include "touch_input.h"
+#include "power_latch.h"
 #include <string.h>
 
 #ifdef TARGET_NRF
@@ -371,6 +372,7 @@ void handleLedStop(uint8_t* data, uint16_t len) {
 }
 
 void processButtonEvents() {
+    powerButtonPoll();
     if (buttonEventPending) {
         buttonEventPending = false;
         uint32_t currentTime = millis();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,6 @@ void setup() {
     Serial.begin(115200);
     delay(100);
     #endif
-    powerLatchBegin();
     allocCompressedDataBuffer();
     writeSerial("=== FIRMWARE INFO ===");
     writeSerial("Firmware Version: " + String(getFirmwareMajor()) + "." + String(getFirmwareMinor()));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "communication.h"
 #include "device_control.h"
 #include "display_service.h"
+#include "power_latch.h"
 #include "touch_input.h"
 #include "encryption.h"
 #include "ble_init.h"
@@ -57,6 +58,7 @@ void setup() {
     Serial.begin(115200);
     delay(100);
     #endif
+    powerLatchBegin();
     allocCompressedDataBuffer();
     writeSerial("=== FIRMWARE INFO ===");
     writeSerial("Firmware Version: " + String(getFirmwareMajor()) + "." + String(getFirmwareMinor()));
@@ -331,6 +333,7 @@ void enterDeepSleep() {
     esp_sleep_enable_timer_wakeup(sleep_timeout_us);
     writeSerial("Entering deep sleep...");
     delay(100); // Brief delay to ensure serial output is sent
+    powerLatchHoldForSleep();
     esp_deep_sleep_start();
 }
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -69,6 +69,7 @@ using namespace Adafruit_LittleFS_Namespace;
 #define DEVICE_FLAG_PWR_PIN      (1 << 0)  // Bit 0: Device has external power management pin
 #define DEVICE_FLAG_XIAOINIT     (1 << 1)  // Bit 1: Call xiaoinit() after config load (nRF52840 only)
 #define DEVICE_FLAG_WS_PP_INIT   (1 << 2)  // Bit 2: Call ws_pp_init() after config load (Waveshare Photo Printer)
+#define DEVICE_FLAG_BATTERY_LATCH (1 << 3) // Bit 3: Self-holding battery latch on pwr_pin_2; optional active-low long-press shutdown button on pwr_pin_3
 
 #ifdef TARGET_NRF
 #include <bluefruit.h>

--- a/src/power_latch.cpp
+++ b/src/power_latch.cpp
@@ -1,0 +1,95 @@
+#include "power_latch.h"
+
+#if defined(OPENDISPLAY_XTEINK_X4)
+
+#include <Arduino.h>
+#include "driver/gpio.h"
+#include "esp_sleep.h"
+
+namespace {
+
+// GPIO13 gates the battery-latch MOSFET: driving it LOW opens the latch and cuts
+// the battery rail entirely. The latch self-holds in hardware once powered, so we
+// never drive it HIGH (see powerLatchBegin). DIO flash mode frees GPIO13 (the QIO
+// write-protect pin) — see the build env.
+constexpr gpio_num_t LATCH_PIN = GPIO_NUM_13;
+// The inset "dimple" button (active-low) — firmware reads it for long-press
+// shutdown. Power-ON is a separate protruding hardware button wired to the power
+// path/reset, not to a GPIO we read.
+constexpr gpio_num_t POWER_BTN_PIN = GPIO_NUM_3;
+constexpr uint32_t POWER_OFF_HOLD_MS = 1500;
+
+// Only arm long-press shutdown after the dimple has been seen released once, so a
+// press still held from a GPIO3-low wake (USB) can't instantly re-trigger it.
+bool buttonReleasedSinceBoot = false;
+bool pressing = false;
+uint32_t pressStartMs = 0;
+
+void powerOff() {
+    // Wait for the dimple to be released before sleeping: we arm a GPIO3-low wake
+    // below, so sleeping while it is still held would immediately wake us again.
+    pinMode(POWER_BTN_PIN, INPUT_PULLUP);
+    while (digitalRead(POWER_BTN_PIN) == LOW) {
+        delay(20);
+    }
+    // Open the latch and hold it across sleep. On battery the rail collapses to a
+    // true zero-drain off (the hardware power button revives it); on USB the rail
+    // stays powered, so we deep-sleep and wake on the next dimple press.
+    gpio_hold_dis(LATCH_PIN);
+    gpio_set_direction(LATCH_PIN, GPIO_MODE_OUTPUT);
+    gpio_set_level(LATCH_PIN, 0);
+    esp_sleep_config_gpio_isolate();
+    gpio_deep_sleep_hold_en();
+    gpio_hold_en(LATCH_PIN);
+    pinMode(POWER_BTN_PIN, INPUT_PULLUP);
+    esp_deep_sleep_enable_gpio_wakeup(1ULL << POWER_BTN_PIN, ESP_GPIO_WAKEUP_GPIO_LOW);
+    esp_deep_sleep_start();
+}
+
+}  // namespace
+
+void powerLatchBegin() {
+    // Mirror crosspoint, the reference firmware for this board: the battery-latch
+    // MOSFET self-holds in hardware once the rail is powered, so firmware never
+    // drives GPIO13 HIGH. It is only ever driven LOW (in powerOff) to cut power.
+    // Release any pin-hold left by a prior deep sleep so GPIO13 returns to hardware
+    // control (a USB wake from powerOff would otherwise keep the latch held open),
+    // then arm the power button.
+    gpio_hold_dis(LATCH_PIN);
+    pinMode(POWER_BTN_PIN, INPUT_PULLUP);
+}
+
+void powerButtonPoll() {
+    const bool down = digitalRead(POWER_BTN_PIN) == LOW;
+    if (!down) {
+        buttonReleasedSinceBoot = true;
+        pressing = false;
+        return;
+    }
+    if (!buttonReleasedSinceBoot) {
+        return;  // still the press that powered the device on
+    }
+    if (!pressing) {
+        pressing = true;
+        pressStartMs = millis();
+        return;
+    }
+    if (millis() - pressStartMs >= POWER_OFF_HOLD_MS) {
+        powerOff();
+    }
+}
+
+void powerLatchHoldForSleep() {
+    gpio_set_direction(LATCH_PIN, GPIO_MODE_OUTPUT);
+    gpio_set_level(LATCH_PIN, 1);
+    gpio_deep_sleep_hold_en();
+    gpio_hold_en(LATCH_PIN);
+}
+
+#else  // not XTEINK X4
+
+void powerLatchBegin() {}
+void powerButtonPoll() {}
+void powerLatchHoldForSleep() {}
+
+#endif

--- a/src/power_latch.cpp
+++ b/src/power_latch.cpp
@@ -1,66 +1,87 @@
 #include "power_latch.h"
 
-#if defined(OPENDISPLAY_XTEINK_X4)
+#if defined(TARGET_ESP32)
 
 #include <Arduino.h>
 #include "driver/gpio.h"
-#include "esp_sleep.h"
+#include "esp_sleep.h"  // pulls in SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+#include "structs.h"
+
+#ifndef DEVICE_FLAG_BATTERY_LATCH
+#define DEVICE_FLAG_BATTERY_LATCH (1 << 3)
+#endif
+
+extern struct GlobalConfig globalConfig;
 
 namespace {
 
-// GPIO13 gates the battery-latch MOSFET: driving it LOW opens the latch and cuts
-// the battery rail entirely. The latch self-holds in hardware once powered, so we
-// never drive it HIGH (see powerLatchBegin). DIO flash mode frees GPIO13 (the QIO
-// write-protect pin) — see the build env.
-constexpr gpio_num_t LATCH_PIN = GPIO_NUM_13;
-// The inset "dimple" button (active-low) — firmware reads it for long-press
-// shutdown. Power-ON is a separate protruding hardware button wired to the power
-// path/reset, not to a GPIO we read.
-constexpr gpio_num_t POWER_BTN_PIN = GPIO_NUM_3;
+// A self-holding battery-latch MOSFET: once the rail is powered the latch holds
+// in hardware, so firmware only ever drives the pin LOW (in powerOff) to cut
+// power. The latch pin and the optional shutdown button come from the device
+// config (pwr_pin_2 / pwr_pin_3)
 constexpr uint32_t POWER_OFF_HOLD_MS = 1500;
 
-// Only arm long-press shutdown after the dimple has been seen released once, so a
-// press still held from a GPIO3-low wake (USB) can't instantly re-trigger it.
+// Only arm long-press shutdown after the button has been seen released once, so a
+// press still held from a GPIO-low wake can't instantly re-trigger it.
 bool buttonReleasedSinceBoot = false;
 bool pressing = false;
 uint32_t pressStartMs = 0;
 
+// 0 is the config's "unset" sentinel and GPIO0 is a strapping pin, so neither 0
+// nor 0xFF is a usable latch/button pin.
+bool validPin(uint8_t pin) { return pin != 0 && pin != 0xFF; }
+
+bool latchEnabled() {
+    return (globalConfig.system_config.device_flags & DEVICE_FLAG_BATTERY_LATCH) &&
+           validPin(globalConfig.system_config.pwr_pin_2);
+}
+gpio_num_t latchPin() { return (gpio_num_t)globalConfig.system_config.pwr_pin_2; }
+int buttonPin() { return globalConfig.system_config.pwr_pin_3; }
+bool hasButton() { return validPin(globalConfig.system_config.pwr_pin_3); }
+
 void powerOff() {
-    // Wait for the dimple to be released before sleeping: we arm a GPIO3-low wake
+    const gpio_num_t latch = latchPin();
+    // Wait for the button to be released before sleeping: we arm a GPIO-low wake
     // below, so sleeping while it is still held would immediately wake us again.
-    pinMode(POWER_BTN_PIN, INPUT_PULLUP);
-    while (digitalRead(POWER_BTN_PIN) == LOW) {
-        delay(20);
+    if (hasButton()) {
+        pinMode(buttonPin(), INPUT_PULLUP);
+        while (digitalRead(buttonPin()) == LOW) {
+            delay(20);
+        }
     }
-    // Open the latch and hold it across sleep. On battery the rail collapses to a
-    // true zero-drain off (the hardware power button revives it); on USB the rail
-    // stays powered, so we deep-sleep and wake on the next dimple press.
-    gpio_hold_dis(LATCH_PIN);
-    gpio_set_direction(LATCH_PIN, GPIO_MODE_OUTPUT);
-    gpio_set_level(LATCH_PIN, 0);
+    // Open the latch and hold it across sleep. On battery this collapses the rail
+    // to a true zero-drain off (a hardware power button revives it). On USB the
+    // rail is fed by USB regardless, so the chip can't power down: it enters deep
+    // sleep but USB brings it straight back up — i.e. an immediate reboot.
+    gpio_hold_dis(latch);
+    gpio_set_direction(latch, GPIO_MODE_OUTPUT);
+    gpio_set_level(latch, 0);
     esp_sleep_config_gpio_isolate();
     gpio_deep_sleep_hold_en();
-    gpio_hold_en(LATCH_PIN);
-    pinMode(POWER_BTN_PIN, INPUT_PULLUP);
-    esp_deep_sleep_enable_gpio_wakeup(1ULL << POWER_BTN_PIN, ESP_GPIO_WAKEUP_GPIO_LOW);
+    gpio_hold_en(latch);
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+    if (hasButton()) {
+        pinMode(buttonPin(), INPUT_PULLUP);
+        esp_deep_sleep_enable_gpio_wakeup(1ULL << buttonPin(), ESP_GPIO_WAKEUP_GPIO_LOW);
+    }
+#endif
     esp_deep_sleep_start();
 }
 
 }  // namespace
 
 void powerLatchBegin() {
-    // Mirror crosspoint, the reference firmware for this board: the battery-latch
-    // MOSFET self-holds in hardware once the rail is powered, so firmware never
-    // drives GPIO13 HIGH. It is only ever driven LOW (in powerOff) to cut power.
-    // Release any pin-hold left by a prior deep sleep so GPIO13 returns to hardware
-    // control (a USB wake from powerOff would otherwise keep the latch held open),
-    // then arm the power button.
-    gpio_hold_dis(LATCH_PIN);
-    pinMode(POWER_BTN_PIN, INPUT_PULLUP);
+    if (!latchEnabled()) return;
+    // Release any pin-hold left by a prior deep sleep so the latch returns to
+    // hardware control (a USB wake from powerOff would otherwise keep it held
+    // open), then arm the shutdown button.
+    gpio_hold_dis(latchPin());
+    if (hasButton()) pinMode(buttonPin(), INPUT_PULLUP);
 }
 
 void powerButtonPoll() {
-    const bool down = digitalRead(POWER_BTN_PIN) == LOW;
+    if (!latchEnabled() || !hasButton()) return;
+    const bool down = digitalRead(buttonPin()) == LOW;
     if (!down) {
         buttonReleasedSinceBoot = true;
         pressing = false;
@@ -80,14 +101,18 @@ void powerButtonPoll() {
 }
 
 void powerLatchHoldForSleep() {
-    gpio_set_direction(LATCH_PIN, GPIO_MODE_OUTPUT);
-    gpio_set_level(LATCH_PIN, 1);
+    if (!latchEnabled()) return;
+    gpio_set_direction(latchPin(), GPIO_MODE_OUTPUT);
+    gpio_set_level(latchPin(), 1);
     gpio_deep_sleep_hold_en();
-    gpio_hold_en(LATCH_PIN);
+    gpio_hold_en(latchPin());
 }
 
-#else  // not XTEINK X4
+#else  // not ESP32
 
+// Battery latch uses ESP-IDF sleep / GPIO-hold APIs; no nRF implementation yet.
+// The DEVICE_FLAG_BATTERY_LATCH config layer is platform-neutral — implement
+// these three here (Nordic sd_power_system_off / GPIO retention) to support it.
 void powerLatchBegin() {}
 void powerButtonPoll() {}
 void powerLatchHoldForSleep() {}

--- a/src/power_latch.h
+++ b/src/power_latch.h
@@ -1,11 +1,13 @@
 #pragma once
 
 // Soft battery-latch / power-button support for devices that gate their own
-// power rail through a MCU-controlled MOSFET (XTEINK X4: GPIO13 holds the
-// battery latch closed, GPIO3 is the active-low power button).
+// power rail through a MCU-controlled MOSFET. Enabled at runtime by the
+// DEVICE_FLAG_BATTERY_LATCH device_flags bit; the latch pin comes from
+// system_config.pwr_pin_2 and the optional active-low shutdown button from
+// pwr_pin_3 (0xFF = none).
 //
-// All functions compile to no-ops unless OPENDISPLAY_XTEINK_X4 is defined, so
-// callers in shared code need no per-board guards.
+// All functions are no-ops on non-ESP32 targets and when the flag is clear, so
+// callers in shared code need no guards.
 
 // Assert the keep-alive latch at boot so the device stays powered on battery.
 // Safe to call on every boot, including timer-wake from deep sleep.

--- a/src/power_latch.h
+++ b/src/power_latch.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// Soft battery-latch / power-button support for devices that gate their own
+// power rail through a MCU-controlled MOSFET (XTEINK X4: GPIO13 holds the
+// battery latch closed, GPIO3 is the active-low power button).
+//
+// All functions compile to no-ops unless OPENDISPLAY_XTEINK_X4 is defined, so
+// callers in shared code need no per-board guards.
+
+// Assert the keep-alive latch at boot so the device stays powered on battery.
+// Safe to call on every boot, including timer-wake from deep sleep.
+void powerLatchBegin();
+
+// Poll the hardware power button; perform a clean power-off on a long press.
+// Cheap; intended to be called from the existing button-polling path.
+void powerButtonPoll();
+
+// Keep the latch closed across OpenDisplay's timer-wake deep sleep so the
+// device retains power and can wake itself. Call immediately before
+// esp_deep_sleep_start().
+void powerLatchHoldForSleep();

--- a/src/structs.h
+++ b/src/structs.h
@@ -28,8 +28,8 @@ struct SystemConfig {
     uint8_t device_flags;       // Misc device flags (bitfield)
     uint8_t pwr_pin;            // Power pin number (0xFF if not present)
     uint8_t reserved[15];       // Reserved bytes for future use
-    uint8_t pwr_pin_2;          // Optional 2nd power/enable (e.g. Seeed ED103 TFT_ENABLE); 0 or 0xFF = default (11)
-    uint8_t pwr_pin_3;          // Optional 3rd power/enable (e.g. ITE_ENABLE); 0 or 0xFF = default (21)
+    uint8_t pwr_pin_2;          // Optional 2nd power/enable (e.g. Seeed ED103 TFT_ENABLE); 0 or 0xFF = default (11). Battery-latch pin when DEVICE_FLAG_BATTERY_LATCH is set.
+    uint8_t pwr_pin_3;          // Optional 3rd power/enable (e.g. ITE_ENABLE); 0 or 0xFF = default (21). Shutdown-button pin (active-low, 0xFF = none) when DEVICE_FLAG_BATTERY_LATCH is set.
 } __attribute__((packed));
 
 // 0x02: manufacturer_data


### PR DESCRIPTION
The [X4](https://www.xteink.com/products/xteink-x4) is an ESP32-C3 e-paper device whose panel is the GDEQ0426T82, already supported by bb_epaper as EP426 (panel_ic_type 0x27 B/W). 

Add:

- esp32-c3-x4 build env: 16MB flash, DIO flash mode (frees GPIO13, the QIO write-protect pin, for the battery-latch MOSFET), no PSRAM, Seeed_GFX ignored.
- power_latch: drives GPIO13 LOW to cut the battery rail (the latch self-holds in hardware, so it is never driven HIGH), handles the GPIO3 dimple-button long-press shutdown, and holds the latch closed across timer deep sleep so the RTC can wake it. All no-ops on other targets.
- main.cpp: begin the latch, detect timer deep-sleep wake (minimal setup, no display refresh), and hold the latch before entering deep sleep.
- device_control.cpp: poll the power button in the button event loop.
- CI: build the esp32-c3-x4 env.