### PR TITLE
Fix 4-gray rendering for bb_epaper panels

### DIFF
--- a/src/boot_screen.cpp
+++ b/src/boot_screen.cpp
@@ -144,6 +144,23 @@ static uint16_t bootTextWidth(const char* s, uint8_t scale) {
     return (!s || scale == 0) ? 0 : (uint16_t)(strlen(s) * 6U * scale);
 }
 
+// 4-gray panels store each pixel's 2-bit code as two separate 1-bit controller
+// planes (LSB -> PLANE_0, MSB -> PLANE_1) combined by the panel's gray LUT.
+// De-interleave one bit of the packed 2bpp row into a 1bpp plane row (MSB-first)
+// and stream it. planeRow scratch lives just past the 2bpp row in staticRowBuffer
+// (200B + 100B for an 800px panel, well within the 680B buffer).
+static void writeGray4PlaneRow(const uint8_t* row2bpp, int pitch2bpp, int planePitch, uint16_t w, int bitSel) {
+    uint8_t* planeRow = staticRowBuffer + pitch2bpp;
+    memset(planeRow, 0x00, planePitch);
+    for (uint16_t x = 0; x < w; x++) {
+        // SSD16xx 4-gray stores the inverted gray code (bb_epaper pColorLookup maps
+        // level -> 3 - level); the boot image uses level 0=black, 3=white.
+        uint8_t code = (uint8_t)((~(row2bpp[x >> 2] >> (6 - ((x & 3) << 1)))) & 0x03);
+        if ((code >> bitSel) & 0x01) planeRow[x >> 3] |= (uint8_t)(0x80 >> (x & 7));
+    }
+    bbepWriteData(&bbep, planeRow, planePitch);
+}
+
 bool writeBootScreenWithQr() {
     const uint16_t w = globalConfig.displays[0].pixel_width;
     const uint16_t h = globalConfig.displays[0].pixel_height;
@@ -227,66 +244,87 @@ bool writeBootScreenWithQr() {
     memcpy(k2, keyHex + 16, 16); k2[16] = '\0';
 
     uint8_t* row = staticRowBuffer;
+    // bb_epaper 4-gray (scheme 5) needs the packed 2bpp image split into two
+    // 1-bit controller planes, so render the frame once per plane and
+    // de-interleave. Every other scheme writes a single packed plane in one pass.
+    const bool gray4Split = (colorScheme == 5)
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
-    if (!seeed_driver_used()) {
-        bbepSetAddrWindow(&bbep, 0, 0, w, h);
-        bbepStartWrite(&bbep, getplane());
-    }
-#else
-    bbepSetAddrWindow(&bbep, 0, 0, w, h);
-    bbepStartWrite(&bbep, getplane());
+        && !seeed_driver_used()
 #endif
-    for (uint16_t y = 0; y < h; y++) {
-        memset(row, whiteValue, pitch);
-        uint16_t availW = qrRight ? qrX : w;
-        uint16_t textY = pad;
-        if (qrRight) {
-            uint16_t lineH = (uint16_t)(scaleText * 10);
-            uint16_t blockH = (uint16_t)(4 * lineH + 7 * scaleText);
-            textY = (qrPx > blockH) ? (uint16_t)(qrY + (qrPx - blockH) / 2) : qrY;
+        ;
+    const int planePitch = (w + 7) / 8;
+    const int planePasses = gray4Split ? 2 : 1;
+    for (int pass = 0; pass < planePasses; pass++) {
+        const int bitSel = pass;  // pass 0 -> LSB/PLANE_0, pass 1 -> MSB/PLANE_1
+        const int targetPlane = gray4Split ? (pass == 0 ? PLANE_0 : PLANE_1)
+                                           : (useBitplanes ? PLANE_0 : getplane());
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
+        if (!seeed_driver_used()) {
+            bbepSetAddrWindow(&bbep, 0, 0, w, h);
+            bbepStartWrite(&bbep, targetPlane);
         }
-        uint16_t dW = bootTextWidth(domainLine, scaleText);
-        uint16_t nW = bootTextWidth(nameLine, scaleText);
-        uint16_t fW = bootTextWidth(fwLine, scaleText);
-        uint16_t k1W = bootTextWidth(k1, scaleText);
-        uint16_t k2W = bootTextWidth(k2, scaleText);
-        uint16_t domX = (dW < availW) ? (uint16_t)((availW - dW) / 2) : pad;
-        uint16_t nameX = (nW < availW) ? (uint16_t)((availW - nW) / 2) : pad;
-        uint16_t fwX = (fW < availW) ? (uint16_t)((availW - fW) / 2) : pad;
-        uint16_t k1X = (k1W < availW) ? (uint16_t)((availW - k1W) / 2) : pad;
-        uint16_t k2X = (k2W < availW) ? (uint16_t)((availW - k2W) / 2) : pad;
-        drawBootTextRow(row, y, domX, textY, domainLine, scaleText, w, pitch, bitsPerPixel, colorScheme);
-        drawBootTextRow(row, y, nameX, (uint16_t)(textY + scaleText * 10), nameLine, scaleText, w, pitch, bitsPerPixel, colorScheme);
-        drawBootTextRow(row, y, fwX, (uint16_t)(textY + scaleText * 20), fwLine, scaleText, w, pitch, bitsPerPixel, colorScheme);
-        drawBootTextRow(row, y, k1X, (uint16_t)(textY + scaleText * 30), k1, scaleText, w, pitch, bitsPerPixel, colorScheme);
-        drawBootTextRow(row, y, k2X, (uint16_t)(textY + scaleText * 40), k2, scaleText, w, pitch, bitsPerPixel, colorScheme);
+#else
+        bbepSetAddrWindow(&bbep, 0, 0, w, h);
+        bbepStartWrite(&bbep, targetPlane);
+#endif
+        for (uint16_t y = 0; y < h; y++) {
+            memset(row, whiteValue, pitch);
+            uint16_t availW = qrRight ? qrX : w;
+            uint16_t textY = pad;
+            if (qrRight) {
+                uint16_t lineH = (uint16_t)(scaleText * 10);
+                uint16_t blockH = (uint16_t)(4 * lineH + 7 * scaleText);
+                textY = (qrPx > blockH) ? (uint16_t)(qrY + (qrPx - blockH) / 2) : qrY;
+            }
+            uint16_t dW = bootTextWidth(domainLine, scaleText);
+            uint16_t nW = bootTextWidth(nameLine, scaleText);
+            uint16_t fW = bootTextWidth(fwLine, scaleText);
+            uint16_t k1W = bootTextWidth(k1, scaleText);
+            uint16_t k2W = bootTextWidth(k2, scaleText);
+            uint16_t domX = (dW < availW) ? (uint16_t)((availW - dW) / 2) : pad;
+            uint16_t nameX = (nW < availW) ? (uint16_t)((availW - nW) / 2) : pad;
+            uint16_t fwX = (fW < availW) ? (uint16_t)((availW - fW) / 2) : pad;
+            uint16_t k1X = (k1W < availW) ? (uint16_t)((availW - k1W) / 2) : pad;
+            uint16_t k2X = (k2W < availW) ? (uint16_t)((availW - k2W) / 2) : pad;
+            drawBootTextRow(row, y, domX, textY, domainLine, scaleText, w, pitch, bitsPerPixel, colorScheme);
+            drawBootTextRow(row, y, nameX, (uint16_t)(textY + scaleText * 10), nameLine, scaleText, w, pitch, bitsPerPixel, colorScheme);
+            drawBootTextRow(row, y, fwX, (uint16_t)(textY + scaleText * 20), fwLine, scaleText, w, pitch, bitsPerPixel, colorScheme);
+            drawBootTextRow(row, y, k1X, (uint16_t)(textY + scaleText * 30), k1, scaleText, w, pitch, bitsPerPixel, colorScheme);
+            drawBootTextRow(row, y, k2X, (uint16_t)(textY + scaleText * 40), k2, scaleText, w, pitch, bitsPerPixel, colorScheme);
 
-        if (y >= qrY && y < (uint16_t)(qrY + qrPx)) {
-            uint16_t localY = (uint16_t)(y - qrY);
-            uint16_t my = (uint16_t)(localY / modulePx);
-            if (my < qrModules) {
-                int16_t qy = (int16_t)my - quiet;
-                for (uint16_t mx = 0; mx < qrModules; mx++) {
-                    int16_t qx = (int16_t)mx - quiet;
-                    bool on = false;
-                    if (qx >= 0 && qy >= 0 && qx < qrSize && qy < qrSize) on = qrcode_getModule(&qr, (uint8_t)qx, (uint8_t)qy);
-                    if (!on) continue;
-                    uint16_t px0 = (uint16_t)(qrX + mx * modulePx);
-                    for (uint16_t px = px0; px < (uint16_t)(px0 + modulePx) && px < w; px++) {
-                        setBootPixelBlack(row, px, pitch, bitsPerPixel, colorScheme);
+            if (y >= qrY && y < (uint16_t)(qrY + qrPx)) {
+                uint16_t localY = (uint16_t)(y - qrY);
+                uint16_t my = (uint16_t)(localY / modulePx);
+                if (my < qrModules) {
+                    int16_t qy = (int16_t)my - quiet;
+                    for (uint16_t mx = 0; mx < qrModules; mx++) {
+                        int16_t qx = (int16_t)mx - quiet;
+                        bool on = false;
+                        if (qx >= 0 && qy >= 0 && qx < qrSize && qy < qrSize) on = qrcode_getModule(&qr, (uint8_t)qx, (uint8_t)qy);
+                        if (!on) continue;
+                        uint16_t px0 = (uint16_t)(qrX + mx * modulePx);
+                        for (uint16_t px = px0; px < (uint16_t)(px0 + modulePx) && px < w; px++) {
+                            setBootPixelBlack(row, px, pitch, bitsPerPixel, colorScheme);
+                        }
                     }
                 }
             }
-        }
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
-        if (seeed_driver_used()) {
-            seeed_gfx_boot_write_row(y, row, pitch);
-        } else {
-            bbepWriteData(&bbep, row, pitch);
-        }
+            if (seeed_driver_used()) {
+                seeed_gfx_boot_write_row(y, row, pitch);
+            } else if (gray4Split) {
+                writeGray4PlaneRow(row, pitch, planePitch, w, bitSel);
+            } else {
+                bbepWriteData(&bbep, row, pitch);
+            }
 #else
-        bbepWriteData(&bbep, row, pitch);
+            if (gray4Split) {
+                writeGray4PlaneRow(row, pitch, planePitch, w, bitSel);
+            } else {
+                bbepWriteData(&bbep, row, pitch);
+            }
 #endif
+        }
     }
 
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
@@ -300,14 +338,6 @@ bool writeBootScreenWithQr() {
             bbepSetAddrWindow(&bbep, 0, 0, w, h);
             bbepStartWrite(&bbep, PLANE_1);
             for (uint16_t y = 0; y < h; y++) bbepWriteData(&bbep, row, pitch);
-        }
-        if (colorScheme == 5) {
-            int otherPlane = (getplane() == PLANE_0) ? PLANE_1 : PLANE_0;
-            int otherPlanePitch = (w + 7) / 8;
-            memset(row, 0x00, otherPlanePitch);
-            bbepSetAddrWindow(&bbep, 0, 0, w, h);
-            bbepStartWrite(&bbep, otherPlane);
-            for (uint16_t y = 0; y < h; y++) bbepWriteData(&bbep, row, otherPlanePitch);
         }
     }
     writeSerial("Boot screen with QR rendered", true);

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1238,13 +1238,18 @@ void decompressDirectWriteData() {
     } while (res == TINF_OK && directWriteBytesWritten < directWriteTotalBytes);
 }
 
-// 4-gray panels keep each pixel's gray code as two 1-bit controller planes
-// (stored = bbep.pColorLookup[level]; plane0 <- stored bit0, plane1 <- stored
-// bit1), exactly as bbepSetPixel4Gray does. The C3 can't hold a full 2bpp frame,
-// so re-decompress the ZIP stream once per plane and de-interleave on the fly.
-// Requires compressed transport (enforced in handleDirectWriteStart).
-static void writeDirectWriteGrayPlane(int plane, int bitSel) {
-    if (!dictionaryBuffer || !decompressionChunk || directWriteCompressedReceived == 0) return;
+// 4-gray uploads arrive as two pre-split 1-bit controller planes concatenated
+// (plane0 then plane1), already gray-coded host-side (py-opendisplay applies the
+// panel's gray LUT, matching bbepSetPixel4Gray: plane0 <- stored bit0, plane1 <-
+// stored bit1). Decompress the ZIP stream once and stream the first plane's bytes
+// to PLANE_0 and the rest to PLANE_1 — no on-device de-interleave or 2bpp frame
+// buffer. Requires compressed transport (enforced in handleDirectWriteStart).
+// Returns true only if both planes were produced in full; the caller must skip
+// the refresh (and etag commit) otherwise, so a short/corrupt stream can't leave
+// a half-written frame on the panel.
+static bool renderDirectWriteGray4(void) {
+    if (!dictionaryBuffer || !decompressionChunk || directWriteCompressedReceived == 0) return false;
+    const uint32_t planeBytes = (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
     struct uzlib_uncomp d;
     memset(&d, 0, sizeof(d));
     d.source = directWriteCompressedBuffer;
@@ -1252,17 +1257,13 @@ static void writeDirectWriteGrayPlane(int plane, int bitSel) {
     d.source_read_cb = NULL;
     uzlib_init();
     int hdr = uzlib_zlib_parse_header(&d);
-    if (hdr < 0) return;
+    if (hdr < 0) return false;
     uint16_t window = 0x100 << hdr;
     if (window > (uint16_t)(32 * 1024)) window = (uint16_t)(32 * 1024);
     uzlib_uncompress_init(&d, dictionaryBuffer, window);
     bbepSetAddrWindow(&bbep, 0, 0, directWriteWidth, directWriteHeight);
-    bbepStartWrite(&bbep, plane);
-    const uint8_t* lut = bbep.pColorLookup;
-    uint8_t outBuf[256];
-    int outLen = 0;
-    uint8_t planeByte = 0;
-    int planeBits = 0;
+    bbepStartWrite(&bbep, PLANE_0);
+    bool onPlane1 = false;
     uint32_t produced = 0;
     int res;
     do {
@@ -1271,34 +1272,22 @@ static void writeDirectWriteGrayPlane(int plane, int bitSel) {
         d.dest_limit = decompressionChunk + 4096;
         res = uzlib_uncompress(&d);
         size_t n = (size_t)(d.dest - d.dest_start);
-        for (size_t bi = 0; bi < n && produced < directWriteTotalBytes; bi++, produced++) {
-            uint8_t src = decompressionChunk[bi];  // 4 pixels, 2bpp, MSB-first
-            for (int k = 0; k < 4; k++) {
-                uint8_t level = (uint8_t)((src >> (6 - (k << 1))) & 0x03);
-                uint8_t stored = (uint8_t)(lut ? (lut[level] & 0x03) : ((~level) & 0x03));
-                planeByte = (uint8_t)((planeByte << 1) | ((stored >> bitSel) & 0x01));
-                if (++planeBits == 8) {
-                    outBuf[outLen++] = planeByte;
-                    planeByte = 0;
-                    planeBits = 0;
-                    if (outLen == (int)sizeof(outBuf)) {
-                        bbepWriteData(&bbep, outBuf, outLen);
-                        outLen = 0;
-                    }
-                }
+        size_t off = 0;
+        while (off < n && produced < 2u * planeBytes) {
+            if (!onPlane1 && produced >= planeBytes) {
+                bbepSetAddrWindow(&bbep, 0, 0, directWriteWidth, directWriteHeight);
+                bbepStartWrite(&bbep, PLANE_1);
+                onPlane1 = true;
             }
+            const uint32_t limit = onPlane1 ? (2u * planeBytes) : planeBytes;
+            size_t take = n - off;
+            if (produced + take > limit) take = (size_t)(limit - produced);
+            bbepWriteData(&bbep, decompressionChunk + off, (int)take);
+            off += take;
+            produced += take;
         }
-    } while (res == TINF_OK && produced < directWriteTotalBytes);
-    if (planeBits) {  // pad a trailing partial byte (non-8-aligned width)
-        planeByte = (uint8_t)(planeByte << (8 - planeBits));
-        outBuf[outLen++] = planeByte;
-    }
-    if (outLen) bbepWriteData(&bbep, outBuf, outLen);
-}
-
-static void renderDirectWriteGray4(void) {
-    writeDirectWriteGrayPlane(PLANE_0, 0);
-    writeDirectWriteGrayPlane(PLANE_1, 1);
+    } while (res == TINF_OK && produced < 2u * planeBytes);
+    return produced == 2u * planeBytes;
 }
 
 void cleanupDirectWriteState(bool refreshDisplay) {
@@ -1356,13 +1345,14 @@ if (partialCtx.active) cleanup_partial_write_state();
         else if (bitsPerPixel == 2) directWriteTotalBytes = (pixels + 3) / 4;
         else directWriteTotalBytes = (pixels + 7) / 8;
     }
-    // 4-gray is de-interleaved into two planes from the re-decompressed ZIP stream
-    // (renderDirectWriteGray4); a full 2bpp frame won't fit RAM uncompressed.
+    // 4-gray arrives as two concatenated 1bpp planes (renderDirectWriteGray4),
+    // streamed to PLANE_0/PLANE_1; a full 2bpp frame won't fit RAM uncompressed.
     const bool gray4 = (colorScheme == 5)
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
         && !seeed_driver_used()
 #endif
         ;
+    if (gray4) directWriteTotalBytes = 2u * (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
     if (gray4 && !directWriteCompressed) {
         cleanupDirectWriteState(false);
         touchResumeAfterEpdRefresh();
@@ -1379,6 +1369,16 @@ if (partialCtx.active) cleanup_partial_write_state();
             return;
         }
         memcpy(&directWriteDecompressedTotal, data, 4);
+        // The host declares the decompressed size; for 4-gray it must match our
+        // two-plane size, or the stream is the wrong shape (packed 2bpp, or a
+        // panel whose width pads differently) — reject before rendering a partial frame.
+        if (gray4 && directWriteDecompressedTotal != directWriteTotalBytes) {
+            cleanupDirectWriteState(false);
+            touchResumeAfterEpdRefresh();
+            uint8_t errorResponse[] = {0xFF, 0xFF};
+            sendResponse(errorResponse, sizeof(errorResponse));
+            return;
+        }
         directWriteCompressedBuffer = compressedDataBuffer;
         directWriteCompressedSize = 0;
         directWriteCompressedReceived = 0;
@@ -1596,9 +1596,19 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
         && !seeed_driver_used()
 #endif
         ;
-    if (directWriteCompressed && directWriteCompressedReceived > 0) {
-        if (gray4) renderDirectWriteGray4();
-        else decompressDirectWriteData();
+    if (gray4) {
+        // 4-gray must produce both planes from the compressed stream. Always run
+        // the render — a missing payload, short, or corrupt stream returns false,
+        // and we NACK rather than refresh stale RAM or commit an etag.
+        if (!renderDirectWriteGray4()) {
+            cleanupDirectWriteState(false);
+            touchResumeAfterEpdRefresh();
+            uint8_t errorResponse[] = {0xFF, 0x72};
+            sendResponse(errorResponse, sizeof(errorResponse));
+            return;
+        }
+    } else if (directWriteCompressed && directWriteCompressedReceived > 0) {
+        decompressDirectWriteData();
     }
     int refreshMode = REFRESH_FULL;
     if (data != nullptr && len >= 1 && data[0] == 1) refreshMode = REFRESH_FAST;

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1238,6 +1238,69 @@ void decompressDirectWriteData() {
     } while (res == TINF_OK && directWriteBytesWritten < directWriteTotalBytes);
 }
 
+// 4-gray panels keep each pixel's gray code as two 1-bit controller planes
+// (stored = bbep.pColorLookup[level]; plane0 <- stored bit0, plane1 <- stored
+// bit1), exactly as bbepSetPixel4Gray does. The C3 can't hold a full 2bpp frame,
+// so re-decompress the ZIP stream once per plane and de-interleave on the fly.
+// Requires compressed transport (enforced in handleDirectWriteStart).
+static void writeDirectWriteGrayPlane(int plane, int bitSel) {
+    if (!dictionaryBuffer || !decompressionChunk || directWriteCompressedReceived == 0) return;
+    struct uzlib_uncomp d;
+    memset(&d, 0, sizeof(d));
+    d.source = directWriteCompressedBuffer;
+    d.source_limit = directWriteCompressedBuffer + directWriteCompressedReceived;
+    d.source_read_cb = NULL;
+    uzlib_init();
+    int hdr = uzlib_zlib_parse_header(&d);
+    if (hdr < 0) return;
+    uint16_t window = 0x100 << hdr;
+    if (window > (uint16_t)(32 * 1024)) window = (uint16_t)(32 * 1024);
+    uzlib_uncompress_init(&d, dictionaryBuffer, window);
+    bbepSetAddrWindow(&bbep, 0, 0, directWriteWidth, directWriteHeight);
+    bbepStartWrite(&bbep, plane);
+    const uint8_t* lut = bbep.pColorLookup;
+    uint8_t outBuf[256];
+    int outLen = 0;
+    uint8_t planeByte = 0;
+    int planeBits = 0;
+    uint32_t produced = 0;
+    int res;
+    do {
+        d.dest_start = decompressionChunk;
+        d.dest = decompressionChunk;
+        d.dest_limit = decompressionChunk + 4096;
+        res = uzlib_uncompress(&d);
+        size_t n = (size_t)(d.dest - d.dest_start);
+        for (size_t bi = 0; bi < n && produced < directWriteTotalBytes; bi++, produced++) {
+            uint8_t src = decompressionChunk[bi];  // 4 pixels, 2bpp, MSB-first
+            for (int k = 0; k < 4; k++) {
+                uint8_t level = (uint8_t)((src >> (6 - (k << 1))) & 0x03);
+                uint8_t stored = (uint8_t)(lut ? (lut[level] & 0x03) : ((~level) & 0x03));
+                planeByte = (uint8_t)((planeByte << 1) | ((stored >> bitSel) & 0x01));
+                if (++planeBits == 8) {
+                    outBuf[outLen++] = planeByte;
+                    planeByte = 0;
+                    planeBits = 0;
+                    if (outLen == (int)sizeof(outBuf)) {
+                        bbepWriteData(&bbep, outBuf, outLen);
+                        outLen = 0;
+                    }
+                }
+            }
+        }
+    } while (res == TINF_OK && produced < directWriteTotalBytes);
+    if (planeBits) {  // pad a trailing partial byte (non-8-aligned width)
+        planeByte = (uint8_t)(planeByte << (8 - planeBits));
+        outBuf[outLen++] = planeByte;
+    }
+    if (outLen) bbepWriteData(&bbep, outBuf, outLen);
+}
+
+static void renderDirectWriteGray4(void) {
+    writeDirectWriteGrayPlane(PLANE_0, 0);
+    writeDirectWriteGrayPlane(PLANE_1, 1);
+}
+
 void cleanupDirectWriteState(bool refreshDisplay) {
     directWriteActive = false;
     directWriteCompressed = false;
@@ -1292,6 +1355,20 @@ if (partialCtx.active) cleanup_partial_write_state();
         if (bitsPerPixel == 4) directWriteTotalBytes = (pixels + 1) / 2;
         else if (bitsPerPixel == 2) directWriteTotalBytes = (pixels + 3) / 4;
         else directWriteTotalBytes = (pixels + 7) / 8;
+    }
+    // 4-gray is de-interleaved into two planes from the re-decompressed ZIP stream
+    // (renderDirectWriteGray4); a full 2bpp frame won't fit RAM uncompressed.
+    const bool gray4 = (colorScheme == 5)
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
+        && !seeed_driver_used()
+#endif
+        ;
+    if (gray4 && !directWriteCompressed) {
+        cleanupDirectWriteState(false);
+        touchResumeAfterEpdRefresh();
+        uint8_t errorResponse[] = {0xFF, 0xFF};
+        sendResponse(errorResponse, sizeof(errorResponse));
+        return;
     }
     if (directWriteCompressed) {
         if (!compressedDataBuffer) {
@@ -1514,7 +1591,15 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
     }
     if (!directWriteActive) return;
     directWriteStartTime = 0;
-    if (directWriteCompressed && directWriteCompressedReceived > 0) decompressDirectWriteData();
+    const bool gray4 = (globalConfig.displays[0].color_scheme == 5)
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
+        && !seeed_driver_used()
+#endif
+        ;
+    if (directWriteCompressed && directWriteCompressedReceived > 0) {
+        if (gray4) renderDirectWriteGray4();
+        else decompressDirectWriteData();
+    }
     int refreshMode = REFRESH_FULL;
     if (data != nullptr && len >= 1 && data[0] == 1) refreshMode = REFRESH_FAST;
     writeSerial("EPD refresh: ", false);

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1238,15 +1238,48 @@ void decompressDirectWriteData() {
     } while (res == TINF_OK && directWriteBytesWritten < directWriteTotalBytes);
 }
 
+// True when the active display uses the bb_epaper 4-gray scheme (two 1-bit
+// controller planes). The Seeed driver path has its own 4bpp handling.
+static inline bool directWriteIsGray4(void) {
+    return (globalConfig.displays[0].color_scheme == 5)
+#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
+        && !seeed_driver_used()
+#endif
+        ;
+}
+
 // 4-gray uploads arrive as two pre-split 1-bit controller planes concatenated
 // (plane0 then plane1), already gray-coded host-side (py-opendisplay applies the
 // panel's gray LUT, matching bbepSetPixel4Gray: plane0 <- stored bit0, plane1 <-
-// stored bit1). Decompress the ZIP stream once and stream the first plane's bytes
-// to PLANE_0 and the rest to PLANE_1 — no on-device de-interleave or 2bpp frame
-// buffer. Requires compressed transport (enforced in handleDirectWriteStart).
-// Returns true only if both planes were produced in full; the caller must skip
-// the refresh (and etag commit) otherwise, so a short/corrupt stream can't leave
-// a half-written frame on the panel.
+// stored bit1). Stream the bytes to the panel, switching from PLANE_0 to PLANE_1
+// at the single-plane boundary — no on-device de-interleave or 2bpp frame buffer.
+// directWriteBytesWritten is the running total across both planes, so the
+// compressed (decompress-at-END) and uncompressed (live 0x71) paths share this
+// one plane-split implementation.
+static void streamGray4Bytes(const uint8_t* buf, uint32_t len) {
+    const uint32_t planeBytes = (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
+    uint32_t off = 0;
+    while (off < len && directWriteBytesWritten < 2u * planeBytes) {
+        if (directWriteBytesWritten == 0u) {
+            bbepSetAddrWindow(&bbep, 0, 0, directWriteWidth, directWriteHeight);
+            bbepStartWrite(&bbep, PLANE_0);
+        } else if (directWriteBytesWritten == planeBytes) {
+            bbepSetAddrWindow(&bbep, 0, 0, directWriteWidth, directWriteHeight);
+            bbepStartWrite(&bbep, PLANE_1);
+        }
+        const uint32_t limit = (directWriteBytesWritten < planeBytes) ? planeBytes : 2u * planeBytes;
+        uint32_t take = len - off;
+        if (directWriteBytesWritten + take > limit) take = limit - directWriteBytesWritten;
+        bbepWriteData(&bbep, (uint8_t*)(buf + off), (int)take);
+        off += take;
+        directWriteBytesWritten += take;
+    }
+}
+
+// Compressed 4-gray: decompress the ZIP stream once and feed the two concatenated
+// planes through streamGray4Bytes. Returns true only if both planes were produced
+// in full; the caller NACKs otherwise so a short/corrupt stream can't leave a
+// half-written frame on the panel.
 static bool renderDirectWriteGray4(void) {
     if (!dictionaryBuffer || !decompressionChunk || directWriteCompressedReceived == 0) return false;
     const uint32_t planeBytes = (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
@@ -1261,10 +1294,6 @@ static bool renderDirectWriteGray4(void) {
     uint16_t window = 0x100 << hdr;
     if (window > (uint16_t)(32 * 1024)) window = (uint16_t)(32 * 1024);
     uzlib_uncompress_init(&d, dictionaryBuffer, window);
-    bbepSetAddrWindow(&bbep, 0, 0, directWriteWidth, directWriteHeight);
-    bbepStartWrite(&bbep, PLANE_0);
-    bool onPlane1 = false;
-    uint32_t produced = 0;
     int res;
     do {
         d.dest_start = decompressionChunk;
@@ -1272,22 +1301,9 @@ static bool renderDirectWriteGray4(void) {
         d.dest_limit = decompressionChunk + 4096;
         res = uzlib_uncompress(&d);
         size_t n = (size_t)(d.dest - d.dest_start);
-        size_t off = 0;
-        while (off < n && produced < 2u * planeBytes) {
-            if (!onPlane1 && produced >= planeBytes) {
-                bbepSetAddrWindow(&bbep, 0, 0, directWriteWidth, directWriteHeight);
-                bbepStartWrite(&bbep, PLANE_1);
-                onPlane1 = true;
-            }
-            const uint32_t limit = onPlane1 ? (2u * planeBytes) : planeBytes;
-            size_t take = n - off;
-            if (produced + take > limit) take = (size_t)(limit - produced);
-            bbepWriteData(&bbep, decompressionChunk + off, (int)take);
-            off += take;
-            produced += take;
-        }
-    } while (res == TINF_OK && produced < 2u * planeBytes);
-    return produced == 2u * planeBytes;
+        if (n > 0) streamGray4Bytes(decompressionChunk, (uint32_t)n);
+    } while (res == TINF_OK && directWriteBytesWritten < 2u * planeBytes);
+    return directWriteBytesWritten == 2u * planeBytes;
 }
 
 void cleanupDirectWriteState(bool refreshDisplay) {
@@ -1345,21 +1361,12 @@ if (partialCtx.active) cleanup_partial_write_state();
         else if (bitsPerPixel == 2) directWriteTotalBytes = (pixels + 3) / 4;
         else directWriteTotalBytes = (pixels + 7) / 8;
     }
-    // 4-gray arrives as two concatenated 1bpp planes (renderDirectWriteGray4),
-    // streamed to PLANE_0/PLANE_1; a full 2bpp frame won't fit RAM uncompressed.
-    const bool gray4 = (colorScheme == 5)
-#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
-        && !seeed_driver_used()
-#endif
-        ;
+    // 4-gray arrives as two concatenated 1bpp planes (plane0 ++ plane1), streamed to
+    // PLANE_0/PLANE_1. Works over both transports: compressed buffers then renders at
+    // END (renderDirectWriteGray4); uncompressed streams the planes live as 0x71
+    // chunks arrive (streamGray4Bytes).
+    const bool gray4 = directWriteIsGray4();
     if (gray4) directWriteTotalBytes = 2u * (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
-    if (gray4 && !directWriteCompressed) {
-        cleanupDirectWriteState(false);
-        touchResumeAfterEpdRefresh();
-        uint8_t errorResponse[] = {0xFF, 0xFF};
-        sendResponse(errorResponse, sizeof(errorResponse));
-        return;
-    }
     if (directWriteCompressed) {
         if (!compressedDataBuffer) {
             cleanupDirectWriteState(false);
@@ -1541,12 +1548,15 @@ void handleDirectWriteData(uint8_t* data, uint16_t len) {
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
         if (seeed_driver_used()) {
             seeed_gfx_direct_write_chunk(data, bytesToWrite);
+            directWriteBytesWritten += bytesToWrite;
         } else
 #endif
-        {
+        if (directWriteIsGray4()) {
+            streamGray4Bytes(data, bytesToWrite);  // advances directWriteBytesWritten, splits planes
+        } else {
             bbepWriteData(&bbep, data, bytesToWrite);
+            directWriteBytesWritten += bytesToWrite;
         }
-        directWriteBytesWritten += bytesToWrite;
     }
     if (directWriteBytesWritten >= directWriteTotalBytes) {
         handleDirectWriteEnd(nullptr, 0);
@@ -1591,16 +1601,16 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
     }
     if (!directWriteActive) return;
     directWriteStartTime = 0;
-    const bool gray4 = (globalConfig.displays[0].color_scheme == 5)
-#if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
-        && !seeed_driver_used()
-#endif
-        ;
+    const bool gray4 = directWriteIsGray4();
     if (gray4) {
-        // 4-gray must produce both planes from the compressed stream. Always run
-        // the render — a missing payload, short, or corrupt stream returns false,
-        // and we NACK rather than refresh stale RAM or commit an etag.
-        if (!renderDirectWriteGray4()) {
+        // Both planes must be present before refresh. Compressed: decompress+stream
+        // now (false on short/corrupt). Uncompressed: planes were streamed live as
+        // 0x71 chunks, so just confirm the full two-plane payload arrived. Either way
+        // a shortfall NACKs rather than refreshing stale RAM or committing an etag.
+        const bool ok = directWriteCompressed
+            ? renderDirectWriteGray4()
+            : (directWriteBytesWritten == directWriteTotalBytes);
+        if (!ok) {
             cleanupDirectWriteState(false);
             touchResumeAfterEpdRefresh();
             uint8_t errorResponse[] = {0xFF, 0x72};


### PR DESCRIPTION
This came up as I was testing everything for https://github.com/OpenDisplay/Firmware/pull/32. Black and white worked great out of the box but grayscale mode did not. It was 'zoomed in' weirdly, and the blacks weren't black and the whites weren't white. Tested these on my local device, looks good (best with Floyd–Steinberg, it had the fewest display artifacts and the best dithering).

Commit message:

bb_epaper stores a 4-gray image as two 1-bit controller planes (LSB -> PLANE_0, MSB -> PLANE_1) combined by the panel's gray LUT, with each pixel's stored code coming from bbep.pColorLookup[level]. Both the boot screen and the BLE direct-write upload path wrote the packed 2bpp data straight into a single plane, so 4-gray panels rendered a doubled-width, mid-gray mess (only 2 of 4 levels, wrong geometry).

De-interleave the 2bpp image into the two planes:

- boot_screen.cpp: render the boot frame once per plane and extract each plane's bit (no extra RAM; reuses the existing row buffer). Replaces the broken single-plane write plus zeroed second plane.
- display_service.cpp: the uploaded image arrives once and the ESP32-C3 can't hold a full 2bpp frame, so re-decompress the ZIP stream once per plane and de-interleave on the fly. 4-gray uploads now require ZIP transport (enforced with a clear error) since an uncompressed frame can't be buffered.

Both use bbep.pColorLookup, so the level->plane mapping is correct for any bb_epaper 4-gray panel. Validated on the XTEINK X4 (EP426): boot screen, solid 4-level bands, and dithered gradients all render correctly.