### PR TITLE
Fix BLE advertising heap leak causing periodic reboots

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1165,7 +1165,6 @@ void updatemsdata(){
                 freshAdvertisementData.setManufacturerData(manufacturerDataStr);
                 *advertisementData = freshAdvertisementData;
                 pAdvertising->setAdvertisementData(freshAdvertisementData);
-                if (pService != nullptr) pAdvertising->addServiceUUID(pService->getUUID());
                 pAdvertising->setScanResponse(false);
                 pAdvertising->setMinPreferred(0x06);
                 pAdvertising->setMinPreferred(0x12);


### PR DESCRIPTION
Found this while having my X4 plugged in and working on the various compression/4-bit/etc PRs. Went from having it reboot every ~hour / 2 hours-ish to running cleanly overnight. Also sniffed bluetooth to ensure the packet was completely unchanged.

Commit message by the robot:

updatemsdata() called pAdvertising->addServiceUUID() on every advertisement refresh in the disconnected branch. BLEAdvertising::addServiceUUID() is a bare push_back into m_serviceUUIDs that is never cleared (freeServiceUUIDs() only frees the encoded p_service_uuid buffer), so the vector grew unbounded until operator new threw std::bad_alloc -> terminate -> abort, rebooting the device roughly every couple of hours.

The call had no effect on what was advertised: the preceding setAdvertisementData() configures the controller with the explicit name/flags/manufacturer-data payload and sets m_customAdvData, and the only code that serializes m_serviceUUIDs (buildRawAdvData, in start()) runs solely in the !m_customAdvData branch. The service UUID was therefore never placed in the advertised packet at all -- fully omitted, not truncated -- so removing the call leaves the advertised bytes byte-for-byte identical.

Verified on an ESP32-C3 (XTEINK X4): ~8 hours with zero reboots, versus a crash about every two hours before.