### PR TITLE
Fix dangling pointer to out-of-scope errorResponse in sendResponse

### DIFF
--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -158,6 +158,7 @@ void sendResponseUnencrypted(uint8_t* response, uint8_t len) {
 
 void sendResponse(uint8_t* response, uint8_t len) {
     static uint8_t encrypted_response[600];
+    uint8_t errorResponse[3];
     if (isAuthenticated() && len >= 2) {
         uint16_t command = (response[0] << 8) | response[1];
         uint8_t status = (len >= 3) ? response[2] : 0x00;
@@ -175,7 +176,9 @@ void sendResponse(uint8_t* response, uint8_t len) {
                 len = encrypted_len;
             } else {
                 writeSerial("WARNING: Failed to encrypt response, sending unencrypted error response", true);
-                uint8_t errorResponse[] = {0xFF, (uint8_t)(command & 0xFF), 0x00};
+                errorResponse[0] = 0xFF;
+                errorResponse[1] = (uint8_t)(command & 0xFF);
+                errorResponse[2] = 0x00;
                 response = errorResponse;
                 len = sizeof(errorResponse);
             }


### PR DESCRIPTION
## Summary

`sendResponse()` in `src/communication.cpp` has a use-after-scope bug. In the branch where response encryption fails, the fallback error buffer is declared **inside** the `else` block:

```cpp
} else {
    uint8_t errorResponse[] = {0xFF, (uint8_t)(command & 0xFF), 0x00};
    response = errorResponse;   // response now points at a block-local
    len = sizeof(errorResponse);
}   // errorResponse's lifetime ends here
```

After the block closes, `response` is still dereferenced for logging, `send_wifi_lan_frame()`, `esp32_queue_ble_notify_copy()`, and `imageCharacteristic.notify()` — all reading a stack object whose lifetime has ended. The bytes happen to survive in practice because nothing has reused the stack yet, but it is undefined behaviour and a latent corruption/crash.

`cppcheck` (`--enable=warning`) independently flags this as `invalidLifetime` at 8 dereference sites.

## Fix

Hoist `errorResponse` to function scope so it outlives the branch, and assign its bytes in place. No behavioural change on the normal/success path.

## Verification

- `cppcheck` no longer reports `invalidLifetime` for this function.
- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4` via PlatformIO.

## Testing to do on hardware

Exercise the response path with encryption enabled and force an encrypt failure (or review the fallback) to confirm the unencrypted error response is still transmitted correctly.