### PR TITLE
Unify ButtonState definition to fix ODR violation and out-of-bounds writes

### DIFF
--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -38,20 +38,6 @@ void cleanupDirectWriteState(bool refreshDisplay);
 void sendResponse(uint8_t* response, uint8_t len);
 void writeSerial(String message, bool newLine = true);
 
-struct ButtonState {
-    uint8_t button_id;
-    uint8_t press_count;
-    volatile uint8_t current_state;
-    uint8_t byte_index;
-    uint8_t pin;
-    uint8_t instance_index;
-    bool initialized;
-    uint8_t pin_offset;
-    bool inverted;
-    bool power_off;
-    uint16_t power_off_hold_ms;
-};
-#define MAX_BUTTONS 32
 extern ButtonState buttonStates[MAX_BUTTONS];
 
 #ifdef TARGET_ESP32

--- a/src/main.h
+++ b/src/main.h
@@ -128,20 +128,6 @@ uint8_t connectionRequested = 0;  // Reserved for future features (connection re
 uint8_t dynamicreturndata[11] = {0};  // Dynamic return data blocks (bytes 2-12 in advertising payload)
 uint8_t msd_payload[16] = {0};  // Manufacturer Specific Data payload (public, updated by updatemsdata())
 
-// Button state tracking structure
-struct ButtonState {
-    uint8_t button_id;          // Button ID (0-7, from instance_number + pin offset)
-    uint8_t press_count;         // Press count (0-15)
-    volatile uint8_t current_state;       // Current button state (0=released, 1=pressed, updated in ISR)
-    uint8_t byte_index;          // Byte index in dynamicreturndata
-    uint8_t pin;                 // GPIO pin number
-    uint8_t instance_index;      // BinaryInputs instance index
-    bool initialized;          // Whether this button is initialized
-    uint8_t pin_offset;         // Pin offset within instance (0-7) for faster ISR lookup
-    bool inverted;              // Inverted flag for this pin (cached for ISR)
-};
-
-#define MAX_BUTTONS 32  // Up to 4 instances * 8 pins = 32 buttons max
 ButtonState buttonStates[MAX_BUTTONS] = {0};  // Button state tracking
 uint8_t buttonStateCount = 0;  // Number of initialized buttons
 volatile bool buttonEventPending = false;  // Flag set by ISR to indicate button event

--- a/src/structs.h
+++ b/src/structs.h
@@ -332,4 +332,19 @@ struct SecurityConfig {
 #define SECURITY_FLAG_RESET_PIN_PULLUP    (1 << 4)
 #define SECURITY_FLAG_RESET_PIN_PULLDOWN  (1 << 5)
 
+#define MAX_BUTTONS 32  // Up to 4 instances * 8 pins = 32 buttons max
+struct ButtonState {
+    uint8_t button_id;          // Button ID (0-7, from instance_number + pin offset)
+    uint8_t press_count;         // Press count (0-15)
+    volatile uint8_t current_state;       // Current button state (0=released, 1=pressed, updated in ISR)
+    uint8_t byte_index;          // Byte index in dynamicreturndata
+    uint8_t pin;                 // GPIO pin number
+    uint8_t instance_index;      // BinaryInputs instance index
+    bool initialized;          // Whether this button is initialized
+    uint8_t pin_offset;         // Pin offset within instance (0-7) for faster ISR lookup
+    bool inverted;              // Inverted flag for this pin (cached for ISR)
+    bool power_off;             // Whether this button triggers a power-off
+    uint16_t power_off_hold_ms; // Hold duration (ms) required to trigger power-off
+};
+
 #endif


### PR DESCRIPTION
## Summary

`ButtonState` is defined **twice with different layouts**, which corrupts memory:

- `src/main.h` defines it with 9 byte-sized fields (`sizeof == 9`) and allocates the storage `ButtonState buttonStates[MAX_BUTTONS]` (288 bytes).
- `src/device_control.cpp` re-declares its own `ButtonState` with two extra fields:
  ```cpp
  bool power_off;
  uint16_t power_off_hold_ms;   // sizeof == 12 after alignment
  ```
  and accesses the same array via `extern ButtonState buttonStates[MAX_BUTTONS];`.

Because the two translation units disagree on `sizeof(ButtonState)`, `device_control.cpp` indexes the array with a **12-byte stride into a 9-byte-stride (288-byte) array**. `initButtons()` writes `.power_off`/`.power_off_hold_ms` on all 32 elements, so the high indices land up to ~96 bytes past the end of `buttonStates[]`, clobbering the adjacent `.bss` globals declared right after it (`buttonStateCount`, `buttonEventPending`, `lastChangedButtonIndex`, ...).

This is an ODR violation (the linker silently picks one layout) plus active memory corruption. `cppcheck` flags it as `ctuOneDefinitionRuleViolation`.

## Fix

Move the single canonical definition — including the `power_off` fields — and `MAX_BUTTONS` into `src/structs.h`, which both `main.cpp` (via `main.h`) and `device_control.cpp` already include. Delete both local copies. `main.h` keeps the array allocation; both sides now see an identical 12-byte layout.

## Verification

- `cppcheck` no longer reports `ctuOneDefinitionRuleViolation`.
- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4` via PlatformIO.

## Testing to do on hardware

Configure buttons across more than one BinaryInputs instance (indices toward the top of the 32-slot array) and confirm button presses register correctly and no unrelated global state (advertising/LED flags) is disturbed.