### PR TITLE
Fix staticRowBuffer overflow on panels wider than the boot scratch row

### DIFF
--- a/src/boot_screen.cpp
+++ b/src/boot_screen.cpp
@@ -18,7 +18,7 @@
 extern struct GlobalConfig globalConfig;
 extern struct SecurityConfig securityConfig;
 extern BBEPDISP bbep;
-extern uint8_t staticRowBuffer[680];
+extern uint8_t staticRowBuffer[BOOT_ROW_BUFFER_SIZE];
 
 String getChipIdHex();
 uint8_t getFirmwareMajor();
@@ -886,6 +886,10 @@ bool writeBootScreenWithQr() {
 #endif
         ;
     const int planePitch = (w + 7) / 8;
+    const size_t rowBytesNeeded = gray4Split ? (size_t)(pitch + planePitch) : (size_t)pitch;
+    if (rowBytesNeeded > sizeof(staticRowBuffer)) {
+        return false;
+    }
     const int planePasses = (gray4Split || colorSwatchPlane1) ? 2 : 1;
     for (int pass = 0; pass < planePasses; pass++) {
         const int bitSel = pass;  // pass 0 -> LSB/PLANE_0, pass 1 -> MSB/PLANE_1

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -203,7 +203,7 @@ static PartialStreamContext partialCtx = {};
 
 extern const uint8_t writelineFont[] PROGMEM;
 extern uint8_t staticWhiteRow[680];
-extern uint8_t staticRowBuffer[680];
+extern uint8_t staticRowBuffer[BOOT_ROW_BUFFER_SIZE];
 extern char staticLineBuffer[256];
 
 int bbepSetPanelType(BBEPDISP *pBBEP, int iPanel);

--- a/src/main.h
+++ b/src/main.h
@@ -150,10 +150,8 @@ uint8_t ledFlashPosition = 0;  // Current position in LED flash pattern group
 uint8_t activeLedInstance = 0xFF;  // LED instance index for flashing (0xFF = none configured)
 bool ledFlashActive = false;  // Flag to indicate if LED flashing is active (set by command)
 
-// Static buffers for writeTextAndFill() to avoid dynamic allocation
-// Maximum pitch: 1360px / 2 = 680 bytes (4BPP), line buffer: 256 bytes
 uint8_t staticWhiteRow[680];
-uint8_t staticRowBuffer[680];
+uint8_t staticRowBuffer[BOOT_ROW_BUFFER_SIZE];
 char staticLineBuffer[256];
 
 char wifiSsid[33] = {0};  // 32 bytes + null terminator

--- a/src/structs.h
+++ b/src/structs.h
@@ -71,6 +71,8 @@ struct PowerOption {
 #define PANEL_IC_SEEED_ED103TC2_1872X1404 3000u
 #define PANEL_IC_SEEED_ED103TC2_1872X1404_4GRAY 3001u
 
+#define BOOT_ROW_BUFFER_SIZE 960
+
 // display.color_scheme (config.yaml); use with matching panel (e.g. gray16 + panel_ic 3001).
 // add more entries to match the ColorScheme enum from bb_epaper
 #define COLOR_SCHEME_MONO 0u


### PR DESCRIPTION
## Summary

The boot-screen renderer overflows its shared scratch buffer on wide 4bpp panels.

`writeBootScreenWithQr()` renders each panel row into the global `staticRowBuffer`, which is 680 bytes:

```cpp
// main.h
uint8_t staticRowBuffer[680];   // "Maximum pitch: 1360px / 2 = 680 bytes (4BPP)"
```

For the supported `PANEL_IC_SEEED_ED103TC2_1872X1404_4GRAY` panel, `getBitsPerPixel()` returns 4, so:

```cpp
if (bitsPerPixel == 4) pitch = w / 2;   // 1872 / 2 = 936
```

Every row then does `memset(row, whiteValue, pitch)` (936 bytes into a 680-byte buffer) and per-pixel writes, and `seeed_gfx_boot_write_row()` reads 936 bytes back out. That is a **256-byte overrun on every row of every boot render** of that panel, corrupting the adjacent `.bss` globals (`staticWhiteRow` / `staticLineBuffer`). The buffer's sizing comment ("max pitch 1360/2 = 680") predates the 1872-wide panel.

## Fix

- Introduce `BOOT_ROW_BUFFER_SIZE` (960) in `structs.h`, sized for the widest supported row: 4bpp @ 1872px = 936 bytes (and the 4-gray 2bpp split path's `pitch + planePitch`, which only occurs on ≤800px panels).
- Size `staticRowBuffer` to `BOOT_ROW_BUFFER_SIZE` and update the two `extern` declarations to match.
- Add a runtime guard in `writeBootScreenWithQr()` that returns `false` (skips rendering) instead of overflowing, should a future panel be wider than the buffer.

RAM cost: +280 bytes of `.bss`.

## Verification

- Compiled clean (not flashed) for `nrf52840custom`, `esp32-N4`, and `esp32-s3-N16R8` (the S3 env is the one that compiles the `OPENDISPLAY_SEEED_GFX` 4bpp path this fix targets).

## Testing to do on hardware

Boot with the 1872×1404 Seeed panel configured in 4-gray (4bpp) mode and confirm the boot screen renders correctly with no corruption of unrelated state.