### PR TITLE
Yield during deep-sleep wake advertising window instead of busy-spinning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,6 +101,7 @@ void loop() {
             enterDeepSleep();
             return;
         }
+        delay(50);
         return;
     }
     if (commandQueueTail != commandQueueHead) {


### PR DESCRIPTION
## Summary

On a battery device, the deep-sleep wake path busy-spins at full clock.

When the device wakes from deep sleep to advertise, `loop()` runs this branch every iteration:

```cpp
if (woke_from_deep_sleep && advertising_timeout_active) {
    if (connected) { ...; return; }
    if (advertising_duration >= advertising_timeout_ms) { enterDeepSleep(); return; }
    return;   // <-- immediately re-enters loop() and spins
}
```

The final bare `return;` means `loop()` re-enters at once and the CPU spins at full clock for the **entire** advertising window (`sleep_timeout_ms`, default 10 s) doing nothing but re-reading the connected count. This is the single most battery-critical path on the device — it runs on every wake.

## Fix

Add `delay(50)` before the return so the core yields between checks (~20 checks/sec instead of thousands). Connection detection latency grows by at most ~50 ms, which is irrelevant here, while active CPU time over the window drops by orders of magnitude.

I kept this to the minimal `delay()` rather than `esp_light_sleep_start()` to avoid any interaction with the BLE controller during the advertising window; a light-sleep variant could be a follow-up.

## Verification

- Compiled clean (not flashed) for `esp32-N4` (this branch is `#ifdef TARGET_ESP32`).

## Testing to do on hardware

Wake from deep sleep without connecting and confirm: (1) the device still connects promptly when a central appears, (2) it returns to deep sleep at the timeout, and (3) measured current during the advertising window drops versus before.