### PR TITLE
Balance touch-suspend counter so touch survives direct-write errors

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1155,6 +1155,7 @@ void initDisplay(){
             bool bootOk = refreshBootScreenFull();
             if (!bootOk && !nrfVbusPresent()) {
                 writeSerial("Boot refresh failed on battery — re-powering panel and retrying", true);
+                touchResumeAfterEpdRefresh();
                 pwrmgm(false);
                 delay(200);
                 prepareEpdRailForBoot();
@@ -1382,6 +1383,8 @@ static void streamGray4Bytes(const uint8_t* buf, uint32_t len) {
     }
 }
 
+static bool directWriteTouchSuspended = false;
+
 void cleanupDirectWriteState(bool refreshDisplay) {
     directWriteActive = false;
     directWriteCompressed = false;
@@ -1408,6 +1411,10 @@ void cleanupDirectWriteState(bool refreshDisplay) {
     }
     displayPowerState = false;
     pwrmgm(false);
+    if (directWriteTouchSuspended) {
+        touchResumeAfterEpdRefresh();
+        directWriteTouchSuspended = false;
+    }
 }
 
 void handleDirectWriteStart(uint8_t* data, uint16_t len) {
@@ -1416,6 +1423,7 @@ if (partialCtx.active) cleanup_partial_write_state();
         cleanupDirectWriteState(false);
     }
     touchSuspendForEpdRefresh();
+    directWriteTouchSuspended = true;
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
     if (seeed_driver_used()) {
         seeed_gfx_prepare_hardware();
@@ -1444,7 +1452,6 @@ if (partialCtx.active) cleanup_partial_write_state();
         memcpy(&directWriteDecompressedTotal, data, 4);
         if (directWriteDecompressedTotal != directWriteTotalBytes) {
             cleanupDirectWriteState(false);
-            touchResumeAfterEpdRefresh();
             uint8_t errorResponse[] = {0xFF, 0xFF};
             sendResponse(errorResponse, sizeof(errorResponse));
             return;
@@ -1662,7 +1669,6 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
         // arrived before refreshing stale RAM or committing an etag.
         if (directWriteBytesWritten != directWriteTotalBytes) {
             cleanupDirectWriteState(false);
-            touchResumeAfterEpdRefresh();
             uint8_t errorResponse[] = {0xFF, 0x72};
             sendResponse(errorResponse, sizeof(errorResponse));
             return;
@@ -1705,7 +1711,6 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
     epdRefreshInProgress = false;
     delay(50);
     cleanupDirectWriteState(false);
-    touchResumeAfterEpdRefresh();
 #ifdef TARGET_ESP32
     esp32_restart_ble_advertising();
 #endif

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -51,7 +51,6 @@ class MyBLEServerCallbacks : public BLEServerCallbacks {
             writeSerial("EPD refresh in progress — deferring cleanup/advertising to main loop");
         } else if (directWriteActive) {
             cleanupDirectWriteState(true);
-            touchResumeAfterEpdRefresh();
         }
         bleRestartAdvertisingPending = true;
     }


### PR DESCRIPTION
## Summary

`touchSuspendForEpdRefresh()` / `touchResumeAfterEpdRefresh()` form a saturating counter that `processTouchInput()` gates on (`s_epd_refresh_suspend > 0` → touch disabled). `handleDirectWriteStart()` suspends once per direct write, but several teardown paths call `cleanupDirectWriteState()` **without** a matching resume, leaking the counter so touch stays disabled **until reboot**:

- compressed-data zlib error cleanup
- start inline-data zlib error
- end final-flush zlib error
- a re-sent start while a direct write is active (suspends again 1→2, only one resume)
- a partial-write start that aborts an active direct write
- the 15-minute direct-write timeout in `loop()`

## Fix

Every direct-write teardown already routes through `cleanupDirectWriteState()`. So:

- Set a `directWriteTouchSuspended` flag right after the suspend in `handleDirectWriteStart()`.
- Resume exactly once in `cleanupDirectWriteState()` when the flag is set, and clear it.
- Remove the now-redundant explicit resume calls this replaces (start size-mismatch, end gray4-incomplete, end success, and the ESP32 disconnect callback).

This makes the pairing robust for **all** teardown paths, including the ones that previously leaked.

Separately, `refreshBootScreenFull()` suspends internally, so the battery-failure boot retry suspended twice against the single caller resume. Added a resume before the retry (a safe no-op if the first attempt never reached its suspend).

## Verification

- Compiled clean (not flashed) for `nrf52840custom`, `esp32-N4`, and `esp32-s3-N16R8` (the S3 env exercises the `seeed_driver_used()` direct-write paths).
- Audited all remaining `touchResumeAfterEpdRefresh()` call sites: only the three boot-path resumes remain; every direct-write resume is now consolidated in `cleanupDirectWriteState()`.

## Testing to do on hardware

On a touch-equipped panel: trigger a failed/aborted direct write (e.g. disconnect mid-stream, or send a mismatched compressed length) and confirm touch still works afterward. Also confirm a normal image write + refresh leaves touch working.