### PR TITLE
Bound led_run_step() to one flash per call to prevent device hang

### DIFF
--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -121,6 +121,7 @@ void reboot(){
 }
 
 #define LED_DELAY_FACTOR_MS 100u
+#define LED_MIN_STEP_DELAY_MS 1u
 
 typedef enum {
     LED_PHASE_IDLE = 0,
@@ -282,9 +283,10 @@ static void led_run_step(void) {
                 if (s_led.loop1delay > 0) {
                     s_led.phase = LED_PHASE_LOOP1_DELAY;
                     led_schedule_delay_ms((uint16_t)(s_led.loop1delay * LED_DELAY_FACTOR_MS));
-                    return;
+                } else {
+                    led_schedule_delay_ms(LED_MIN_STEP_DELAY_MS);
                 }
-                break;
+                return;
 
             case LED_PHASE_LOOP1_DELAY:
                 s_led.phase = LED_PHASE_LOOP1;
@@ -309,9 +311,10 @@ static void led_run_step(void) {
                 if (s_led.loop2delay > 0) {
                     s_led.phase = LED_PHASE_LOOP2_DELAY;
                     led_schedule_delay_ms((uint16_t)(s_led.loop2delay * LED_DELAY_FACTOR_MS));
-                    return;
+                } else {
+                    led_schedule_delay_ms(LED_MIN_STEP_DELAY_MS);
                 }
-                break;
+                return;
 
             case LED_PHASE_LOOP2_DELAY:
                 s_led.phase = LED_PHASE_LOOP2;
@@ -330,16 +333,18 @@ static void led_run_step(void) {
                     }
                     s_led.group_pos++;
                     s_led.phase = LED_PHASE_GROUP;
-                    break;
+                    led_schedule_delay_ms(LED_MIN_STEP_DELAY_MS);
+                    return;
                 }
                 flashLed(s_led.c3, s_led.brightness);
                 s_led.i3++;
                 if (s_led.loop3delay > 0) {
                     s_led.phase = LED_PHASE_LOOP3_DELAY;
                     led_schedule_delay_ms((uint16_t)(s_led.loop3delay * LED_DELAY_FACTOR_MS));
-                    return;
+                } else {
+                    led_schedule_delay_ms(LED_MIN_STEP_DELAY_MS);
                 }
-                break;
+                return;
 
             case LED_PHASE_LOOP3_DELAY:
                 s_led.phase = LED_PHASE_LOOP3;


### PR DESCRIPTION
## Summary

`led_run_step()` runs a `for(;;)` state machine that only returns when it schedules a delay or finishes. `processLedFlash()` calls it once per `loop()` iteration, so:

- A pattern with **zero inter-flash delays** runs *all* its flashes in a single call, blocking `loop()` (and thus BLE/touch/buttons) for the entire sequence — `flashLed()` busy-waits ~11 ms each, so e.g. 3×15 flashes × 254 repeats blocks for ~2 minutes.
- With `grouprepeats == 255` (treated as infinite) **and** all delays zero, it never returns — spinning forever. That is a WDT reset on ESP32 and a dead device on nRF.

Both are reachable from an attacker- or bug-supplied `0x0077` LED activate payload.

## Fix

Make `led_run_step()` execute **at most one flash per invocation**: after each flash, and at each group-repeat boundary, yield by scheduling a minimum step delay (`LED_MIN_STEP_DELAY_MS = 1`) when no delay is configured — instead of looping back to flash again. `processLedFlash()` then re-enters on the next `loop()` iteration.

This bounds each call to one flash (so `loop()` keeps servicing BLE/touch/buttons between flashes) and cannot spin, while preserving the configured cadence whenever a real delay is set. The group-boundary yield also covers the degenerate all-loop-counts-zero infinite-repeat pattern.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

Send an LED activate command with (a) a normal blink pattern — confirm timing looks unchanged; (b) zero delays + high/infinite repeats — confirm the device stays responsive (BLE/touch still work) and does not reset.