### PR TITLE
Cap total buzzer playback duration to bound blocking time

### DIFF
--- a/src/buzzer_control.cpp
+++ b/src/buzzer_control.cpp
@@ -12,6 +12,7 @@ static constexpr uint32_t kBuzzerFreqMinHz = 400u;
 static constexpr uint32_t kBuzzerFreqMaxHz = 12000u;
 static constexpr uint8_t kBuzzerDurationUnitMs = 5u;
 static constexpr uint32_t kBuzzerInterPatternGapMs = 20u;
+static constexpr uint32_t kBuzzerMaxTotalMs = 5000u;
 
 static uint32_t buzzer_index_to_hz(uint8_t idx) {
     if (idx == 0) {
@@ -144,19 +145,30 @@ void handleBuzzerActivate(uint8_t* data, uint16_t len) {
         return;
     }
 
-    for (uint8_t rep = 0; rep < outer; rep++) {
+    const uint32_t playStart = millis();
+    bool capped = false;
+    for (uint8_t rep = 0; rep < outer && !capped; rep++) {
         uint16_t poff = 3;
-        for (uint8_t pi = 0; pi < pattern_count; pi++) {
+        for (uint8_t pi = 0; pi < pattern_count && !capped; pi++) {
             uint8_t nsteps = data[poff++];
             for (uint8_t si = 0; si < nsteps; si++) {
+                uint32_t elapsed = millis() - playStart;
+                if (elapsed >= kBuzzerMaxTotalMs) {
+                    capped = true;
+                    break;
+                }
                 uint8_t fidx = data[poff++];
                 uint8_t dunit = data[poff++];
                 uint32_t hz = buzzer_index_to_hz(fidx);
                 uint32_t ms = (uint32_t)dunit * (uint32_t)kBuzzerDurationUnitMs;
+                uint32_t remaining = kBuzzerMaxTotalMs - elapsed;
+                if (ms > remaining) {
+                    ms = remaining;
+                }
                 buzzer_set_enable(b, true);
                 buzzer_drive_tone_sw(b, hz, ms);
             }
-            if (pi + 1 < pattern_count) {
+            if (!capped && pi + 1 < pattern_count) {
                 delay(kBuzzerInterPatternGapMs);
             }
         }


### PR DESCRIPTION
## Summary

`handleBuzzerActivate()` plays `outer * pattern_count * nsteps` tones in a fully blocking software bit-bang loop (`buzzer_drive_tone_sw` busy-waits with `delayMicroseconds`). Each tone is up to `255 * 5 = 1275 ms`, and `outer`/`pattern_count`/`nsteps` are attacker-/caller-controlled, so a single `0x0077` payload can block for **hours**:

- On nRF the handler runs in the Bluefruit write callback, so a long buzz blocks the BLE stack and drops the connection.
- On ESP32 it starves the `loop()` task and trips the task watchdog.

## Fix

Add a `kBuzzerMaxTotalMs` (5 s) cap. Playback stops once accumulated time reaches the cap, and the final tone is clamped to the remaining budget so total blocking time can never exceed it. Normal short alert patterns are unaffected.

This is a minimal, low-risk bound on the worst case. A fully non-blocking buzzer state machine (like the LED path already uses) would be the better long-term fix and could be a follow-up.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

Play a normal short pattern and confirm it sounds unchanged; then send an oversized/high-repeat pattern and confirm playback stops at ~5 s, the BLE connection survives (nRF), and the device does not reset (ESP32).