### PR TITLE
Rate-limit blocking sensor reads in updatemsdata() with a 30s cache

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1200,7 +1200,7 @@ int getBitsPerPixel() {
     return 1;
 }
 
-float readBatteryVoltage() {
+static float readBatteryVoltageUncached() {
     if (bq27220IsConfigured()) {
         float gaugeV = bq27220BatteryVoltageVolts();
         if (gaugeV >= 0.0f) {
@@ -1229,6 +1229,20 @@ float readBatteryVoltage() {
     }
     if (scalingFactor > 0) return (adcAverage * scalingFactor) / (100000.0);
     return -1.0;
+}
+
+static constexpr uint32_t kBatteryVoltageTtlMs = 30000u;
+float readBatteryVoltage() {
+    static uint32_t lastReadMs = 0;
+    static float cachedVoltage = -1.0f;
+    static bool haveReading = false;
+    if (haveReading && (uint32_t)(millis() - lastReadMs) < kBatteryVoltageTtlMs) {
+        return cachedVoltage;
+    }
+    cachedVoltage = readBatteryVoltageUncached();
+    lastReadMs = millis();
+    haveReading = true;
+    return cachedVoltage;
 }
 
 float readChipTemperature() {

--- a/src/sensor_bq27220.cpp
+++ b/src/sensor_bq27220.cpp
@@ -138,11 +138,20 @@ void initBq27220Sensors(void) {
     writeSerial("BQ27220: fuel gauge @0x" + String(bq27220_addr_7bit(s), HEX), true);
 }
 
+static constexpr uint32_t kBq27220MsdPollTtlMs = 30000u;
+
 void pollBq27220ForMsd(void) {
     const SensorData* s = bq27220_config();
     if (!s) {
         return;
     }
+    static uint32_t lastPollMs = 0;
+    static bool havePolled = false;
+    if (havePolled && (uint32_t)(millis() - lastPollMs) < kBq27220MsdPollTtlMs) {
+        return;
+    }
+    lastPollMs = millis();
+    havePolled = true;
     uint8_t raw[2];
     if (!bq27220_read_block(s, BQ27220_CMD_VOLTAGE, raw, 2)) {
         s_gauge_ok = false;

--- a/src/sensor_sht40.cpp
+++ b/src/sensor_sht40.cpp
@@ -236,8 +236,17 @@ void initSht40Sensors(void) {
     }
 }
 
+static constexpr uint32_t kSht40MsdPollTtlMs = 30000u;
+
 void pollSht40SensorsForMsd(void) {
     static bool logged_fail = false;
+    static uint32_t lastPollMs = 0;
+    static bool havePolled = false;
+    if (havePolled && (uint32_t)(millis() - lastPollMs) < kSht40MsdPollTtlMs) {
+        return;
+    }
+    lastPollMs = millis();
+    havePolled = true;
     for (uint8_t i = 0; i < globalConfig.sensor_count; i++) {
         const SensorData* s = &globalConfig.sensors[i];
         if (s->sensor_type != SENSOR_TYPE_SHT40) {


### PR DESCRIPTION
## Summary

`updatemsdata()` rebuilds the manufacturer-specific advertising data and is called on **every button press** and on **every touch coordinate change** (up to ~10 Hz while dragging), as well as on connect. Each call did a full blocking sensor sweep:

- `pollSht40SensorsForMsd()` — ~12 ms per SHT40 read, and up to ~100 ms when the configured address fails and it walks the candidate list with a Wire bus re-init.
- `pollBq27220ForMsd()` — two blocking I2C transactions.
- `readBatteryVoltage()` — ~30 ms (10 `analogRead` samples with `delay(2)` plus a `delay(10)` settle).

So interacting with the device spends a large fraction of CPU time blocked in sensor delays — a latency and battery problem.

## Fix

Cache each source with a 30 s TTL:

- The SHT40 and BQ27220 polls write their MSD bytes **in place** and updatemsdata() never clears them, so on a cache hit the poll simply returns and the previously written bytes stay valid.
- `readBatteryVoltage()` is refactored into a cached wrapper over the existing body (`readBatteryVoltageUncached()`), returning the cached value on a hit. This also removes the ~30 ms blocking read from the boot screen footer.

Event-driven `updatemsdata()` calls now just repack cached data. Sensor values still refresh at least every 30 s, which is ample for temperature/humidity/battery in an advertisement. (A runtime sensor-config change self-corrects within one TTL.)

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

Confirm the MSD advert still reports sensible temperature/humidity/battery and updates within ~30 s; verify touch dragging and button presses are noticeably more responsive; and confirm a disconnected/failing SHT40 no longer stalls every event.