### PR TITLE
Reset config buffer capacity each load so larger reloads succeed

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -234,7 +234,7 @@ bool loadGlobalConfig(){
     wifiEncryptionType = 0;
     globalConfig.data_extended_loaded = false;
     static uint8_t configData[MAX_CONFIG_SIZE];
-    static uint32_t configLen = MAX_CONFIG_SIZE;
+    uint32_t configLen = MAX_CONFIG_SIZE;
     if (!loadConfig(configData, &configLen)) {
         globalConfig.loaded = false;
         return false;


### PR DESCRIPTION
## Summary

`loadGlobalConfig()` fails to reload a config that is larger than the previously loaded one, until the device reboots.

```cpp
static uint8_t configData[MAX_CONFIG_SIZE];
static uint32_t configLen = MAX_CONFIG_SIZE;   // <-- static, initialized once
if (!loadConfig(configData, &configLen)) { ... }
```

`loadConfig()` uses `*len` as the input buffer **capacity** and overwrites it with the actual config size on success. Because `configLen` is `static`, the next call starts with the *previous* config's size. If the new config is larger, `loadConfig()` rejects it ("Config data larger than buffer").

`loadGlobalConfig()` is called at runtime after every BLE config write (`reloadConfigAfterSave()`), so a user who writes a larger config sees it saved to flash but not applied until reboot.

## Fix

Make `configLen` a plain local, re-initialized to `MAX_CONFIG_SIZE` on every call. The large `configData` buffer stays `static` to avoid stack usage.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

Write a small config, then write a larger config over BLE and confirm it is applied without a reboot (previously the second write would be saved but rejected on reload).