### PR TITLE
Raise decompression chunk size 256 -> 2048 to cut SPI transactions

### DIFF
--- a/src/display_service.h
+++ b/src/display_service.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define OPENDISPLAY_DECOMPRESSION_CHUNK_SIZE 256
+#define OPENDISPLAY_DECOMPRESSION_CHUNK_SIZE 2048
 
 bool seeed_driver_used(void);
 int mapEpd(int id);


### PR DESCRIPTION
## Summary

During a compressed image transfer, every `od_zlib_stream_poll()` output chunk is written to the panel in a single `bbepWriteData()` / SPI transaction (CS assert, DC set, transaction setup). With `OPENDISPLAY_DECOMPRESSION_CHUNK_SIZE = 256`:

- an 800×480 mono frame → ~188 transactions
- the 1.3 MB Seeed 4-gray frame → ~5100 poll iterations

Most of that is fixed per-transaction overhead on the throughput-critical image path.

## Fix

Raise the chunk to 2048 bytes, cutting the transaction count ~8× for the same data. The only cost is a larger static `decompressionChunk` buffer (+1792 bytes of `.bss`). No call site assumes the old value — every consumer (`seeed_gfx_direct_write_chunk`, `streamGray4Bytes`, `bbepWriteData`, `partial_write_stream_bytes`) takes `(buffer, length)`.

## Verification

- Compiled clean (not flashed) for `nrf52840custom`, `esp32-N4`, and `esp32-s3-N16R8`.

## Testing to do on hardware

Transfer a compressed image on both a small mono panel and the Seeed 4-gray panel; confirm the image renders correctly and transfer time is unchanged or improved.