### PR TITLE
Don't block setup() waiting for WiFi association

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ void setup() {
     ble_nrf_advertising_start();
 #endif
     #ifdef TARGET_ESP32
-    initWiFi();
+    initWiFi(false);
     #endif
     updatemsdata();
     initButtons();


### PR DESCRIPTION
## Summary

`setup()` calls `initWiFi()` with the default `waitForConnection = true`, which polls for association with up to 3 retries × 10 s of `delay(500)` plus a `delay(2000)` between retries — stalling boot for up to **~34 s**. During that time BLE is already advertising but queued commands go unprocessed.

`handleWiFiServer()` in `loop()` already handles late association asynchronously, and the deep-sleep `minimalSetup()` path already uses `initWiFi(false)`.

## Fix

Pass `initWiFi(false)` from `setup()` as well, so boot proceeds immediately and WiFi connects in the background.

## Verification

- Compiled clean (not flashed) for `esp32-N4` (WiFi path is `#ifdef TARGET_ESP32`).

## Testing to do on hardware

Boot with WiFi configured and confirm: boot completes promptly (no ~30 s stall), BLE is responsive immediately, and the device still associates and serves the WiFi LAN transfer once connected.