### PR TITLE
Widen sendResponse() length parameter to uint16_t to avoid truncation

### DIFF
--- a/src/buzzer_control.cpp
+++ b/src/buzzer_control.cpp
@@ -4,7 +4,7 @@
 #include <string.h>
 
 extern struct GlobalConfig globalConfig;
-void sendResponse(uint8_t* response, uint8_t len);
+void sendResponse(uint8_t* response, uint16_t len);
 
 static_assert(sizeof(PassiveBuzzerConfig) == 32, "PassiveBuzzerConfig must be 32 bytes");
 

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -38,7 +38,7 @@ static void reloadConfigAfterSave(void) {
 bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* ciphertext,
                     uint16_t* ciphertext_len, uint8_t* nonce, uint8_t* auth_tag);
 bool isEncryptionEnabled();
-void sendResponseUnencrypted(uint8_t* response, uint8_t len);
+void sendResponseUnencrypted(uint8_t* response, uint16_t len);
 void secureEraseConfig();
 extern struct SecurityConfig securityConfig;
 typedef struct {
@@ -120,7 +120,7 @@ static constexpr uint8_t FIRMWARE_SHA_HEX_BYTES = 40;
 static const char kFirmwareShaPlaceholder[FIRMWARE_SHA_HEX_BYTES + 1] =
     "0000000000000000000000000000000000000000";
 
-void sendResponseUnencrypted(uint8_t* response, uint8_t len) {
+void sendResponseUnencrypted(uint8_t* response, uint16_t len) {
     writeSerial("Sending unencrypted response (error/status):", true);
     writeSerial("  Length: " + String(len) + " bytes", true);
     writeSerial("  Command: 0x" + String(response[0], HEX) + String(response[1], HEX), true);
@@ -156,7 +156,7 @@ void sendResponseUnencrypted(uint8_t* response, uint8_t len) {
 #endif
 }
 
-void sendResponse(uint8_t* response, uint8_t len) {
+void sendResponse(uint8_t* response, uint16_t len) {
     static uint8_t encrypted_response[600];
     if (isAuthenticated() && len >= 2) {
         uint16_t command = (response[0] << 8) | response[1];

--- a/src/communication.h
+++ b/src/communication.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 
-void sendResponseUnencrypted(uint8_t* response, uint8_t len);
-void sendResponse(uint8_t* response, uint8_t len);
+void sendResponseUnencrypted(uint8_t* response, uint16_t len);
+void sendResponse(uint8_t* response, uint16_t len);
 uint16_t calculateCRC16CCITT(uint8_t* data, uint32_t len);
 uint8_t getFirmwareMajor();
 uint8_t getFirmwareMinor();

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -35,7 +35,7 @@ extern volatile uint8_t lastChangedButtonIndex;
 extern "C" uint8_t pinToButtonIndex[64];
 void updatemsdata();
 void cleanupDirectWriteState(bool refreshDisplay);
-void sendResponse(uint8_t* response, uint8_t len);
+void sendResponse(uint8_t* response, uint16_t len);
 void writeSerial(String message, bool newLine = true);
 
 struct ButtonState {

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -27,7 +27,7 @@ using namespace Adafruit_LittleFS_Namespace;
 #include <esp_system.h>
 #endif
 
-void sendResponse(uint8_t* response, uint8_t len);
+void sendResponse(uint8_t* response, uint16_t len);
 bool aes_cmac(const uint8_t* key, const uint8_t* message, size_t message_len, uint8_t* mac);
 bool aes_ecb_encrypt(const uint8_t* key, const uint8_t* input, uint8_t* output);
 bool aes_ccm_encrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,

--- a/src/main.h
+++ b/src/main.h
@@ -219,8 +219,8 @@ String getChipIdHex();
 #endif
 
 void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uint16_t len);
-void sendResponse(uint8_t* response, uint8_t len);
-void sendResponseUnencrypted(uint8_t* response, uint8_t len);
+void sendResponse(uint8_t* response, uint16_t len);
+void sendResponseUnencrypted(uint8_t* response, uint16_t len);
 void secureEraseConfig();
 void checkResetPin();
 void reboot();


### PR DESCRIPTION
## Summary

`sendResponse()` builds an encrypted response and assigns its length back into its own `len` parameter:

```cpp
uint16_t encrypted_len = 0;
if (encryptResponse(response, len, encrypted_response, &encrypted_len, nonce, auth_tag)) {
    response = encrypted_response;
    len = encrypted_len;   // len is uint8_t -> truncates
}
```

`len` was `uint8_t`, but `encryptResponse` can produce up to `2 + 16 + 254 + 12 = 284` bytes, which truncates to `len & 0xFF` (284 → 28). The `static uint8_t encrypted_response[600]` buffer shows large responses were anticipated. It is latent today (no plaintext response exceeds ~100 bytes) but is a silent-corruption landmine.

## Fix

Widen `len` to `uint16_t` on `sendResponse()` and `sendResponseUnencrypted()` and on every forward declaration (`communication.h`/`.cpp`, `main.h`, `encryption.cpp`, `buzzer_control.cpp`, `device_control.cpp`) so all callers resolve the same symbol (these are distinct overloads in C++, so every declaration must match). All internal `len` math and the BLE/LAN sinks already accept `uint16_t`.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

Regression only — confirm normal encrypted and unencrypted responses (acks, config reads, MSD reads) still round-trip correctly.