### PR TITLE
Guard button event read-and-clear against ISR race

### DIFF
--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -424,9 +424,11 @@ void processButtonEvents() {
     pollConfiguredPowerOffButtons();
 #endif
     if (buttonEventPending) {
+        noInterrupts();
         buttonEventPending = false;
         uint8_t changedButtonIndex = lastChangedButtonIndex;
         lastChangedButtonIndex = 0xFF;
+        interrupts();
         writeSerial("Button event pending: " + String(changedButtonIndex));
         if (changedButtonIndex < MAX_BUTTONS && buttonStates[changedButtonIndex].initialized) {
             ButtonState* btn = &buttonStates[changedButtonIndex];


### PR DESCRIPTION
## Summary

`processButtonEvents()` reads and clears the ISR-shared event slot non-atomically:

```cpp
buttonEventPending = false;
uint8_t changedButtonIndex = lastChangedButtonIndex;
lastChangedButtonIndex = 0xFF;
```

If the button ISR fires between the index copy and the `= 0xFF` store, the ISR's freshly written `lastChangedButtonIndex` is overwritten with `0xFF` while `buttonEventPending` remains `true`. The next pass then processes index `0xFF` — which fails the `< MAX_BUTTONS` check and is silently dropped — so a real button press is lost.

## Fix

Wrap the three-assignment read-and-clear in `noInterrupts()` / `interrupts()` so the ISR cannot interleave. This is the pattern used elsewhere for ISR-shared state; the critical section is tiny.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

Rapidly press a configured button and confirm every press registers (no dropped presses), and that button state still updates normally.