### PR TITLE
Clear touch IRQ mask atomically w.r.t. the touch ISRs

### DIFF
--- a/src/touch_input.cpp
+++ b/src/touch_input.cpp
@@ -104,7 +104,9 @@ static void touch_disable_controller(uint8_t idx, TouchController* tc, TouchRunt
             detachInterrupt(irq_num);
         }
         rt->int_irq_attached = 0;
+        noInterrupts();
         s_touch_irq_mask &= (uint8_t)~(1u << idx);
+        interrupts();
     }
     writeSerial("Touch[" + String(idx) + "]: disabled (" + String(reason) + ")", true);
 }
@@ -585,7 +587,9 @@ void processTouchInput(void) {
             }
             if (edge) {
                 from_irq = true;
+                noInterrupts();
                 s_touch_irq_mask &= (uint8_t)~(1u << i);
+                interrupts();
             }
         } else {
             timed_poll = (uint32_t)(now - rt->last_poll_ms) >= interval;


### PR DESCRIPTION
## Summary

`s_touch_irq_mask` is set by the per-controller touch ISRs with `|=` and cleared in main context with a non-atomic read-modify-write at two sites (`touch_input.cpp:107` and `:588`):

```cpp
s_touch_irq_mask &= (uint8_t)~(1u << i);
```

If an ISR sets a different controller's bit between the load and the store, that bit is erased and the edge is lost. With a single controller the timed-poll fallback eventually recovers it (latency, not permanent loss), but with multiple controllers it defeats the interrupt path.

## Fix

Wrap both clear sites in `noInterrupts()` / `interrupts()`. The single-byte *read* at `:575` (`edge = (mask & (1<<i)) != 0`) is atomic and left as-is.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

With one or more interrupt-driven touch controllers, confirm touch remains responsive and no touches are dropped under rapid input.