### PR TITLE
Skip nRF advertising rebuild when MSD payload is unchanged

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1274,6 +1274,13 @@ void updatemsdata(){
     msd_payload[14] = batteryVoltageLowByte;
     msd_payload[15] = statusByte;
 #ifdef TARGET_NRF
+    static uint8_t prev_msd_payload_nrf[16] = {0xFF};
+    if (memcmp(prev_msd_payload_nrf, msd_payload, 16) == 0) {
+        mloopcounter++;
+        mloopcounter &= 0x0F;
+        return;
+    }
+    memcpy(prev_msd_payload_nrf, msd_payload, 16);
     Bluefruit.Advertising.clearData();
     Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
     Bluefruit.Advertising.addName();


### PR DESCRIPTION
## Summary

`updatemsdata()` runs on every loop wake. The nRF path unconditionally tears down and rebuilds the advertisement each call:

```cpp
#ifdef TARGET_NRF
    Bluefruit.Advertising.clearData();
    ...
    Bluefruit.Advertising.setFastTimeout(1);
    Bluefruit.Advertising.stop();
    Bluefruit.Advertising.start(0);
#endif
```

With `setFastTimeout(1)`, every restart burns a fast-advertising burst — even when the 16-byte MSD payload has not changed. The ESP32 path immediately below already short-circuits with a `memcmp` against the previous payload.

## Fix

Add the same unchanged-payload guard to the nRF path — its own static `prev_msd_payload_nrf`, the same `mloopcounter` heartbeat, and an early return on a match — leaving the working ESP32 path untouched.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

On an nRF device, confirm the advertisement still updates promptly when sensor/battery data changes, that a scanner sees the expected MSD, and (if measurable) that advertising is no longer restarted every loop when idle.