### PR TITLE
Set epdRefreshInProgress during partial refresh

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1997,7 +1997,9 @@ static bool partial_write_to_panel(int refreshMode) {
 
     if (partialCtx.bytes_written != partialCtx.expected_stream_size) return false;
     delay(20);
+    epdRefreshInProgress = true;
     bool refreshSuccess = partial_trigger_refresh(refreshMode);
+    epdRefreshInProgress = false;
     bbepSleep(&bbep, 1);
     delay(50);
     displayPowerState = false;


### PR DESCRIPTION
## Summary

`partial_write_to_panel()` runs a blocking ~60 s refresh (`partial_trigger_refresh` → `bbepRefresh` + `waitforrefresh`) **without** setting `epdRefreshInProgress`, unlike the direct-write path in `handleDirectWriteEnd()` (which sets it around its refresh).

Several consumers depend on that flag:

- the ESP32 disconnect callback defers cleanup/advertising to the main loop while a refresh is running;
- the advertising-restart gate checks it;
- the keep-awake `bleActive` computation in `loop()` includes it.

During a partial refresh, all of these saw "no refresh running", so e.g. a disconnect could tear down the panel mid-refresh.

## Fix

Set `epdRefreshInProgress = true` around `partial_trigger_refresh()` and clear it right after the refresh wait — matching the direct-write path's ordering (cleared before the panel sleep/power-down).

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

Trigger a partial refresh and disconnect the BLE central mid-refresh; confirm the panel completes the refresh cleanly (cleanup is deferred to the loop) rather than being torn down mid-operation.