### PR TITLE
Make BLE command queue indices volatile (cross-task publish)

### DIFF
--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -24,8 +24,8 @@ struct CommandQueueItem {
 };
 
 extern CommandQueueItem commandQueue[COMMAND_QUEUE_SIZE];
-extern uint8_t commandQueueHead;
-extern uint8_t commandQueueTail;
+extern volatile uint8_t commandQueueHead;
+extern volatile uint8_t commandQueueTail;
 extern uint8_t rebootFlag;
 extern volatile bool esp32BleNotifySubscribed;
 

--- a/src/main.h
+++ b/src/main.h
@@ -377,8 +377,8 @@ uint8_t responseQueueTail = 0;
 #include "esp32_ble_callbacks.h"
 
 CommandQueueItem commandQueue[COMMAND_QUEUE_SIZE];
-uint8_t commandQueueHead = 0;
-uint8_t commandQueueTail = 0;
+volatile uint8_t commandQueueHead = 0;
+volatile uint8_t commandQueueTail = 0;
 
 BLEServer* pServer = nullptr;
 BLEService* pService = nullptr;


### PR DESCRIPTION
## Summary

On ESP32, `onWrite()` runs in the Bluedroid/NimBLE **host task** and publishes a queued command:

```cpp
memcpy(commandQueue[commandQueueHead].data, data, len);
commandQueue[commandQueueHead].pending = true;
commandQueueHead = nextHead;
```

while `loop()` (the Arduino task) polls `commandQueueTail != commandQueueHead`. But `commandQueueHead` / `commandQueueTail` were plain non-`volatile` globals, so the compiler may cache them in registers across loop iterations — a newly queued command can go unnoticed until something else forces a reload.

## Fix

Mark `commandQueueHead` / `commandQueueTail` `volatile` at the definition (`main.h`) and the `extern` (`esp32_ble_callbacks.h`). This matches the existing `bleRestartAdvertisingPending` pattern.

`volatile` is the minimal correct fix for visibility here; a stronger version would use `std::atomic<uint8_t>` with acquire/release semantics or a FreeRTOS queue, which could be a follow-up.

## Verification

- Compiled clean (not flashed) for `esp32-N4` and `nrf52840custom`.

## Testing to do on hardware

Stream a BLE image transfer (many 512-byte command packets) and confirm no commands are dropped/stalled — i.e. transfers complete reliably.