### PR TITLE
Defer WiFi startup on deep-sleep wake until a central connects

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,7 +249,6 @@ void minimalSetup() {
     full_config_init();
     initio();
     ble_init_esp32(true); // Update manufacturer data
-    initWiFi(false);
     writeSerial("=== BLE advertising started (minimal mode) ===");
     writeSerial("Advertising for 10 seconds, waiting for connection...");
     advertising_timeout_active = true;
@@ -258,6 +257,7 @@ void minimalSetup() {
 
 void fullSetupAfterConnection() {
     writeSerial("=== Full Setup After Connection ===");
+    initWiFi(false);
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
     if (globalConfig.display_count > 0 && seeed_driver_used()) {
         writeSerial("Panel: Seeed ED103 (bb_epaper not used)", true);


### PR DESCRIPTION
## Summary

`minimalSetup()` (the deep-sleep wake path) started WiFi with `initWiFi(false)`, but the advertising-window branch of `loop()` `return`s before `handleWiFiServer()` is ever reached. So during the ~10 s advertising window the STA radio drew power for no benefit unless a BLE central connected — and `fullSetupAfterConnection()` didn't start WiFi either, so the radio was simultaneously powered-but-unserviced.

## Fix

Move the WiFi startup out of `minimalSetup()` and into `fullSetupAfterConnection()`. The radio now stays off during the idle advertising window (saving power on this battery-powered path) but is still brought up for the session once a central actually connects. It remains non-blocking (`initWiFi(false)`), and `handleWiFiServer()` drives association in the normal loop.

## Verification

- Compiled clean (not flashed) for `esp32-N4` and `nrf52840custom`.

## Testing to do on hardware

Wake from deep sleep and (a) let the advertising window expire without connecting — confirm WiFi radio is off / lower current; (b) connect a central during the window — confirm WiFi still associates and the WiFi LAN transfer works.