### PR TITLE
Engage nRF advertising boost on button press (ordering fix)

### DIFF
--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -443,10 +443,10 @@ void processButtonEvents() {
                 dynamicreturndata[btn->byte_index] = buttonData;
             }
         }
-        updatemsdata();
 #ifdef TARGET_NRF
         ble_nrf_boost_advertising();
 #endif
+        updatemsdata();
     }
 }
 


### PR DESCRIPTION
## Summary

On nRF, a button press is supposed to briefly boost the advertising rate (20–30 ms interval for 3 s) so the change propagates quickly. But it never engages on a single press.

The button handler did:

```cpp
updatemsdata();            // restarts advertising via ble_nrf_apply_adv_interval()
#ifdef TARGET_NRF
ble_nrf_boost_advertising();   // only NOW sets s_nrf_adv_boost_until
#endif
```

`updatemsdata()` restarts advertising through `ble_nrf_apply_adv_interval()`, but at that point the boost deadline is still unset, so it applies the **normal** interval. `ble_nrf_boost_advertising()` then sets the deadline, but `ble_nrf_advertising_tick()` merely `return`s while boosting without re-applying the interval or restarting advertising. So the boost interval is only ever applied if a *second* event restarts advertising within the 3 s window.

## Fix

Set the boost deadline **before** `updatemsdata()`, so its advertising restart picks up the fast interval.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

On an nRF device, press a configured button and confirm (e.g. via a BLE sniffer or faster scan-response updates) that advertising speeds up for ~3 s after the press.