### PR TITLE
Minor correctness fixes: config wipe secrets, TLV bound, dead copy

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -139,6 +139,11 @@ bool clearStoredConfig(void) {
     }
     #endif
     memset(&globalConfig, 0, sizeof(globalConfig));
+    memset(&securityConfig, 0, sizeof(securityConfig));
+    wifiConfigured = false;
+    wifiSsid[0] = '\0';
+    wifiPassword[0] = '\0';
+    wifiEncryptionType = 0;
     return true;
 }
 
@@ -523,7 +528,7 @@ bool loadGlobalConfig(){
                 break;
             case 0x27: // security_config
                 {
-                    if (offset + sizeof(struct SecurityConfig) <= configLen) {
+                    if (offset + sizeof(struct SecurityConfig) <= configLen - 2) {
                         memcpy(&securityConfig, &configData[offset], sizeof(struct SecurityConfig));
                         offset += sizeof(struct SecurityConfig);
                         // Check if key is all zeros (encryption disabled)

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -700,11 +700,9 @@ bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* cipher
                                    ad, 2, payload_with_length, total_payload_len,
                                    ciphertext + 2 + 16, auth_tag, 12);
     if (!success) return false;
-    uint8_t nonce_copy[16];
-    memcpy(nonce_copy, nonce, 16);
     ciphertext[0] = plaintext[0];
     ciphertext[1] = plaintext[1];
-    memcpy(ciphertext + 2, nonce_copy, 16);
+    memcpy(ciphertext + 2, nonce, 16);
     memcpy(ciphertext + 2 + 16 + total_payload_len, auth_tag, 12);
     *ciphertext_len = 2 + 16 + total_payload_len + 12;
     updateEncryptionSessionActivity();


### PR DESCRIPTION
## Summary

Three small, low-severity correctness fixes (grouped):

1. **`clearStoredConfig()` left secrets in RAM.** It only `memset` `globalConfig`, so after the BLE clear-config command (0x0045) the old `securityConfig` (AES key, `encryption_enabled`) and the WiFi credential globals stayed live until reboot. Now it also zeroes `securityConfig` and resets `wifiConfigured`/`wifiSsid`/`wifiPassword`/`wifiEncryptionType`, mirroring the reset block in `loadGlobalConfig()`.

2. **`security_config` (0x27) packet bound was off by two.** It checked `offset + sizeof(SecurityConfig) <= configLen`, while every other packet case uses `configLen - 2` (the trailing CRC). A truncated packet could read the 2 CRC bytes into `securityConfig` instead of being rejected. Now uses `configLen - 2`.

3. **Dead `nonce_copy` bounce in `encryptResponse()`.** Removed a redundant `memcpy` of `nonce` into a local before copying it into the ciphertext; copy `nonce` directly.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

- Send the clear-config command with encryption + WiFi configured; confirm subsequent operations require re-auth / re-provision (old key/credentials no longer active without reboot).
- Regression: normal config load with a security_config packet still parses; encrypted responses still round-trip.