### PR TITLE
Skip empty rows in the boot color-plane pass (BWR/BWY)

### DIFF
--- a/src/boot_screen.cpp
+++ b/src/boot_screen.cpp
@@ -912,7 +912,12 @@ bool writeBootScreenWithQr() {
         const bool colorPlanePass = colorSwatchPlane1 && pass == 1;
         for (uint16_t y_native = 0; y_native < h; y_native++) {
             memset(row, colorPlanePass ? 0x00 : whiteValue, pitch);
-            for (uint16_t x_native = 0; x_native < w; x_native++) {
+            bool colorRowOutsideBand = false;
+            if (colorPlanePass && (rotation == 0 || rotation == 2)) {
+                const int rowLy = (rotation == 2) ? (int)(h_log - 1u - y_native) : (int)y_native;
+                colorRowOutsideBand = (rowLy < swatchY0 || rowLy >= swatchY1);
+            }
+            for (uint16_t x_native = 0; !colorRowOutsideBand && x_native < w; x_native++) {
                 // Map native pixel to logical (user-visible) coordinates
                 uint16_t lx, ly;
                 switch (rotation) {


### PR DESCRIPTION
## Summary

For BWR/BWY panels the boot renderer runs a second full-frame pass to build the PLANE_1 color plane, but only the footer swatch band — a contiguous range of logical-y rows `[swatchY0, swatchY1)` — can set any bits there. The pass nonetheless walked every pixel of every row, running the per-pixel rotation transform and `bootSwatchIndex`/`bootSwatchIsBorder` lookups on rows that can only produce zeros.

## Fix

In the color-plane pass, for rotation 0/2 the logical y is constant per native row, so compute it once and skip the inner x-loop for rows outside the swatch band. Those rows are already zeroed by the existing `memset(row, 0x00, pitch)`, so the correct (empty) row is still written. Rotation 1/3 (where logical y varies within a native row) and the main non-color pass are left untouched.

## Verification

- Compiled clean (not flashed) for `nrf52840custom`, `esp32-N4`, and `esp32-s3-N16R8`.

## Testing to do on hardware

Boot a BWR (or BWY) panel in each rotation (0/90/180/270) and confirm the footer color swatches render identically to before — only the color-plane render time should differ.