### PR TITLE
Defer BLE-callback display teardown and MSD update to the main loop (ESP32)

### DIFF
--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -137,6 +137,8 @@ void ble_init() {
 
 #ifdef TARGET_ESP32
 volatile bool bleRestartAdvertisingPending = false;
+volatile bool bleConnectMsdUpdatePending = false;
+volatile bool bleDirectWriteCleanupPending = false;
 volatile bool esp32BleNotifySubscribed = false;
 #if defined(CONFIG_BLUEDROID_ENABLED)
 static BLE2902* s_bleNotifyCccd = nullptr;

--- a/src/ble_init.h
+++ b/src/ble_init.h
@@ -15,6 +15,8 @@ void esp32_restart_ble_advertising(void);
 void esp32_ble_clear_handles(void);
 bool esp32_ble_notify_enabled(void);
 extern volatile bool bleRestartAdvertisingPending;
+extern volatile bool bleConnectMsdUpdatePending;
+extern volatile bool bleDirectWriteCleanupPending;
 extern volatile bool esp32BleNotifySubscribed;
 #endif
 

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -41,7 +41,7 @@ class MyBLEServerCallbacks : public BLEServerCallbacks {
         writeSerial("=== BLE CLIENT CONNECTED (ESP32) ===");
         rebootFlag = 0;
         esp32BleNotifySubscribed = false;
-        updatemsdata();
+        bleConnectMsdUpdatePending = true;
     }
     void onDisconnect(BLEServer* pServer) {
         (void)pServer;
@@ -50,8 +50,7 @@ class MyBLEServerCallbacks : public BLEServerCallbacks {
         if (epdRefreshInProgress) {
             writeSerial("EPD refresh in progress — deferring cleanup/advertising to main loop");
         } else if (directWriteActive) {
-            cleanupDirectWriteState(true);
-            touchResumeAfterEpdRefresh();
+            bleDirectWriteCleanupPending = true;
         }
         bleRestartAdvertisingPending = true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,6 +134,17 @@ void loop() {
     if (bleRestartAdvertisingPending) {
         esp32_restart_ble_advertising();
     }
+    if (bleConnectMsdUpdatePending) {
+        bleConnectMsdUpdatePending = false;
+        updatemsdata();
+    }
+    if (bleDirectWriteCleanupPending) {
+        bleDirectWriteCleanupPending = false;
+        if (directWriteActive) {
+            cleanupDirectWriteState(true);
+            touchResumeAfterEpdRefresh();
+        }
+    }
     if (directWriteActive && directWriteStartTime > 0) {
         uint32_t directWriteDuration = millis() - directWriteStartTime;
         if (directWriteDuration > 900000UL) {  // 15 minute timeout (upload + refresh window)


### PR DESCRIPTION
## Summary

On ESP32, `onConnect()` and `onDisconnect()` run in the BLE host task, but they performed work that races the Arduino `loop()` task:

- `onConnect()` called `updatemsdata()` — I2C sensor reads and mutation of shared MSD/advertising state — concurrently with the same work in `loop()`.
- `onDisconnect()` called `cleanupDirectWriteState(true)` — `bbepSleep` / `SPI.end()` / `Wire.end()` / `pwrmgm(false)` — while `loop()` may be mid `bbepWriteData` on the same SPI bus during a direct-write upload (the `epdRefreshInProgress` guard only covers the refresh phase, not the upload phase). That powers the panel down under an in-flight transfer and clears state the handler is still using.

## Fix

Set pending flags in the callbacks and perform the work in `loop()`, mirroring the existing `bleRestartAdvertisingPending` deferral: `onConnect` sets `bleConnectMsdUpdatePending`, `onDisconnect` sets `bleDirectWriteCleanupPending`, and `loop()` acts on them right after the advertising-restart handling.

## Verification

- Compiled clean (not flashed) for `esp32-N4` and `nrf52840custom`.

⚠️ **Needs on-hardware testing.** This changes concurrency timing on ESP32. Please verify: (1) connecting refreshes the MSD/advertisement as before; (2) disconnecting **during** a direct-write image upload cleanly aborts and powers the panel down without a crash or bus fault; (3) a normal image upload + refresh still completes. Note this touches the same `onDisconnect` block as #56 (touch-suspend), so the two will need a trivial merge.