### PR TITLE
Try a lightweight GT911 probe before full reset on EPD-refresh resume

### DIFF
--- a/src/touch_input.cpp
+++ b/src/touch_input.cpp
@@ -387,6 +387,30 @@ static bool touch_reinit_gt911(uint8_t idx, TouchController* tc, TouchRuntime* r
     return true;
 }
 
+static bool touch_light_resume_gt911(uint8_t idx, TouchController* tc, TouchRuntime* rt) {
+    if (tc->touch_ic_type != TOUCH_IC_GT911 || !rt->ok || rt->addr7 == 0) {
+        return false;
+    }
+    if (!touch_ensure_bus(tc)) {
+        return false;
+    }
+    uint8_t id[4];
+    if (!gt911_read_reg(rt->addr7, GT911_REG_PID, id, 4, rt->reg_high_first != 0) ||
+        !gt911_product_id_match(id)) {
+        return false;
+    }
+    rt->i2c_fail_streak = 0;
+    rt->touch_latched = 0;
+    gt911_clear_status(rt->addr7, rt->reg_high_first != 0);
+    if (tc->int_pin != 0xFF) {
+        gt911_int_wake_before_irq(tc);
+        if (!rt->int_irq_attached) {
+            attach_touch_int(idx, tc->int_pin);
+        }
+    }
+    return true;
+}
+
 void touchResumeAfterEpdRefresh(void) {
     if (s_epd_refresh_suspend == 0) {
         return;
@@ -406,7 +430,9 @@ void touchResumeAfterEpdRefresh(void) {
         if (tc->touch_ic_type != TOUCH_IC_GT911 || rt->disabled) {
             continue;
         }
-        if (touch_reinit_gt911(i, tc, rt)) {
+        if (touch_light_resume_gt911(i, tc, rt)) {
+            writeSerial("Touch[" + String(i) + "]: light resume after EPD @0x" + String(rt->addr7, HEX), true);
+        } else if (touch_reinit_gt911(i, tc, rt)) {
             writeSerial("Touch[" + String(i) + "]: reinit OK after EPD @0x" + String(rt->addr7, HEX), true);
         } else {
             writeSerial("Touch[" + String(i) + "]: reinit failed after EPD refresh", true);


### PR DESCRIPTION
## Summary

After every EPD refresh, `touchResumeAfterEpdRefresh()` ran a full GT911 hardware reset through `touch_reinit_gt911()` → `gt911_resolve_and_init()` — a reset pulse plus fixed settle delays plus address re-resolution, roughly 500–700 ms of blocking work per controller during which buttons and BLE stall. In the common case the controller is still alive at its known address, so the full reset is wasted.

## Fix

Add `touch_light_resume_gt911()`: read the GT911 product ID at the last-known address, and if it still answers, just clear the status register and re-attach the interrupt — no reset, no address scan. This is the same lightweight path `initTouchInput()` already uses for a "kept post-EPD" controller. The full `touch_reinit_gt911()` is used only as a fallback when the probe fails, so a controller that genuinely dropped out is still recovered. The one-time bus invalidate + settle before the loop is unchanged.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

⚠️ **Needs on-hardware testing with a GT911 touch panel.** Touch bring-up timing is device-specific. Please verify after several EPD refreshes that: (1) touch still responds (fast path works), and (2) if you force the controller to drop (e.g. power-cycle its rail), the fallback full reinit still recovers it.