### PR TITLE
Read stored config once on boot instead of twice

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -790,10 +790,12 @@ void full_config_init() {
     return;
 #endif
 
-    tryProvisionFactoryEmbed();
-
     writeSerial("Loading global configuration...");
-    if (loadGlobalConfig()) {
+    bool configLoaded = loadGlobalConfig();
+    if (!configLoaded && tryProvisionFactoryEmbed()) {
+        configLoaded = loadGlobalConfig();
+    }
+    if (configLoaded) {
         writeSerial("Global configuration loaded successfully");
         printConfigSummary();
         clearEncryptionSession();

--- a/src/factory_config.cpp
+++ b/src/factory_config.cpp
@@ -45,10 +45,6 @@ static bool factoryEmbedPresent(const factory_flash_cfg_t* fc) {
 }
 
 bool tryProvisionFactoryEmbed(void) {
-    if (hasValidStoredConfig()) {
-        return false;
-    }
-
 #ifdef FACTORY_HAS_EMBED
     if (!factoryEmbedPresent(&g_factory_embed)) {
         return false;


### PR DESCRIPTION
## Summary

On every boot, `full_config_init()` read and CRC'd the stored config twice: `tryProvisionFactoryEmbed()` → `hasValidStoredConfig()` → `loadConfig()` (a full flash read plus a bitwise CRC32 over up to 4 KB), followed immediately by `loadGlobalConfig()` → `loadConfig()` again.

## Fix

Reorder to load first, and only provision from the factory embed and reload when the load fails (i.e. the config is missing or corrupt). The `hasValidStoredConfig()` guard inside `tryProvisionFactoryEmbed()` is removed because it is now only called after a failed load, which already means there is no valid stored config.

Behaviour is preserved: a normal boot with a valid config does a single read; a missing or CRC-corrupt config still triggers factory provisioning and a reload (the recovery path now does the two reads, but only in that rare case).

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

⚠️ **Worth testing the provisioning path on hardware:** boot with (1) a valid stored config, (2) no stored config on a build with a factory embed — confirm it provisions and loads, and (3) if easy to simulate, a corrupt stored config — confirm it re-provisions rather than bricking.