### PR TITLE
Drop per-iteration "Loop end" debug log on nRF

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,7 +217,6 @@ void loop() {
     ble_nrf_advertising_tick();
     processButtonEvents();
     processTouchInput();
-    writeSerial("Loop end: " + String(millis() / 100));
     #endif
 }
 


### PR DESCRIPTION
## Summary

The nRF `loop()` ran `writeSerial("Loop end: " + String(millis() / 100))` on every iteration. That builds an Arduino `String` (a heap alloc/free) each pass — and under `DISABLE_USB_SERIAL` the argument `String` is still constructed even though `writeSerial()` compiles to a no-op body, so the churn happens even with logging off. It is the highest-frequency `String` allocation in the firmware.

## Fix

Remove the log line. It is debug noise with no production value.

This is a targeted piece of the broader "String logging churn" issue: many other log sites still build `String` arguments unconditionally. The complete fix is a `LOG(...)` macro that compiles the argument away when logging is disabled, which is a much larger change across hundreds of call sites and left as a follow-up.

## Verification

- Compiled clean (not flashed) for `nrf52840custom`.

## Testing to do on hardware

None required — this only removes a debug print. Optionally confirm the serial log no longer prints "Loop end" spam.