### PR TITLE
Set max preferred connection interval instead of min twice (ESP32)

### DIFF
--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -247,10 +247,10 @@ void ble_init_esp32(bool update_manufacturer_data) {
     pAdvertising->setAdvertisementData(*advertisementData);
     pAdvertising->setScanResponse(false);
     pAdvertising->setMinPreferred(0x0006);
-    pAdvertising->setMinPreferred(0x0012);
+    pAdvertising->setMaxPreferred(0x0012);
     writeSerial("Advertising intervals set");
     pServer->getAdvertising()->setMinPreferred(0x06);
-    pServer->getAdvertising()->setMinPreferred(0x12);
+    pServer->getAdvertising()->setMaxPreferred(0x12);
     pServer->getAdvertising()->start();
     writeSerial("=== BLE advertising started successfully ===");
     writeSerial("Device ready: " + deviceName);

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1315,7 +1315,7 @@ void updatemsdata(){
                 pAdvertising->setAdvertisementData(freshAdvertisementData);
                 pAdvertising->setScanResponse(false);
                 pAdvertising->setMinPreferred(0x06);
-                pAdvertising->setMinPreferred(0x12);
+                pAdvertising->setMaxPreferred(0x12);
                 delay(50);
                 pAdvertising->start();
             }


### PR DESCRIPTION
## Summary

The ESP32 advertising setup called `setMinPreferred()` twice with 0x06 then 0x12, so the second call overwrote the first and the preferred **max** connection interval was never set:

```cpp
pAdvertising->setMinPreferred(0x0006);
pAdvertising->setMinPreferred(0x0012);   // overwrites min; max never set
```

The upstream ESP32 BLE example this pattern comes from sets `setMinPreferred(0x06)` and `setMaxPreferred(0x12)`.

## Fix

Change the second call at each of the three sites (two in `ble_init.cpp`, one in `display_service.cpp`) to `setMaxPreferred()`, so both the min and max preferred connection intervals are advertised as intended.

## Verification

- Compiled clean (not flashed) for `esp32-N4` (confirms `setMaxPreferred` exists in the pinned arduino-esp32) and `nrf52840custom`.

## Testing to do on hardware

Optional: connect a central and confirm the negotiated connection interval still lands in the expected range; this only changes an advertised preference the central may honor.