### PR TITLE
Remove dead pinToButtonIndex array

### DIFF
--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -32,7 +32,6 @@ extern uint8_t dynamicreturndata[11];
 extern uint8_t buttonStateCount;
 extern volatile bool buttonEventPending;
 extern volatile uint8_t lastChangedButtonIndex;
-extern "C" uint8_t pinToButtonIndex[64];
 void updatemsdata();
 void cleanupDirectWriteState(bool refreshDisplay);
 void sendResponse(uint8_t* response, uint8_t len);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,9 +239,6 @@ void idleDelay(uint32_t delayMs) {
     }
 }
 
-#ifdef TARGET_NRF
-uint8_t pinToButtonIndex[64] = {0xFF};  // Map pin number to button index (max 64 pins)
-#endif
 
 #ifdef TARGET_ESP32
 void minimalSetup() {


### PR DESCRIPTION
## Summary

`pinToButtonIndex[64]` was defined in `main.cpp` (under `TARGET_NRF`) and declared `extern` in `device_control.cpp`, but it is never read or written anywhere. Its aggregate initializer `{0xFF}` also only set element 0 (the rest zero-initialize to a valid button index), so it was a latent landmine if it were ever wired up.

## Fix

Delete the definition and the `extern` declaration.

## Verification

- Compiled clean (not flashed) for `nrf52840custom` and `esp32-N4`.

## Testing to do on hardware

None — dead-code removal only.