### PR TITLE
fix: re-init I2C bus before AXP2101 probe in initAXP2101

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -646,6 +646,10 @@ void initAXP2101(uint8_t busId){
         writeSerial("ERROR: Bus " + String(busId) + " is not an I2C bus", true);
         return;
     }
+    if(!initOrRestoreWireForBus(busId)){
+        writeSerial("ERROR: Failed to (re)init I2C bus " + String(busId) + " for AXP2101", true);
+        return;
+    }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     uint8_t error = Wire.endTransmission();
     if(error != 0){


### PR DESCRIPTION
## Summary

Fixes the image-upload hang on boards with an AXP2101 PMIC (Waveshare ESP32-S3-PhotoPainter and friends) — see #37 and [my analysis comment there](https://github.com/OpenDisplay/Firmware/issues/37#issuecomment-4887431778).

After the display is powered down, `invalidateOpenDisplayWire()` calls `Wire.end()`, leaving the I2C bus uninitialized. The next display power-up (e.g. an image upload via `0x0070`) calls `initAXP2101()`, which probes the PMIC on the dead bus:

```
=== DIRECT WRITE START COMMAND (0x0070) ===
Powering up AXP2101 PMIC...
=== Initializing AXP2101 PMIC ===
ERROR: AXP2101 not found at address 0x34 (error: 4)
```

The early return leaves the panel power rails (DCDC1/ALDO3/ALDO4) disabled, so the subsequent panel init blocks forever on the BUSY line — the device stops ACKing and reports "transfer already in progress" until reboot. Boot-screen rendering works because the bus is freshly initialized at boot, which is what makes this so confusing to debug.

## Fix

Restore the bus with the existing `initOrRestoreWireForBus()` helper before probing.

## Test plan

- [x] Waveshare ESP32-S3-PhotoPainter (esp32-s3-N16R8, built from main @ 8a1dabb): `AXP2101 detected at address 0x34`, panel refresh completes in ~31.5 s
- [x] Repeated uploads over BLE (Home Assistant core integration) succeed
- [x] Repeated uploads over the WiFi/LAN transport (port 2446) succeed
- [x] Boot screen renders and refreshes normally

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)