### PR TITLE
fix: write both bitplanes for BWR/BWY direct display

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1387,13 +1387,15 @@ static inline bool directWriteIsGray4(void) {
         ;
 }
 
-// 4-gray uploads arrive as two pre-split 1-bit controller planes concatenated
-// (plane0 then plane1), already gray-coded host-side (py-opendisplay applies the
-// panel's gray LUT, matching bbepSetPixel4Gray: plane0 <- stored bit0, plane1 <-
-// stored bit1). Stream the bytes to the panel, switching from PLANE_0 to PLANE_1
-// at the single-plane boundary - no on-device de-interleave or 2bpp frame buffer.
-// directWriteBytesWritten is the running total across both planes, so the
-// compressed and uncompressed paths share this one plane-split implementation.
+// Two-plane uploads (4-gray and BWR/BWY) arrive as two pre-split, row-padded 1-bit
+// controller planes concatenated (plane0 then plane1). 4-gray is already gray-coded
+// host-side (py-opendisplay applies the panel's gray LUT, matching bbepSetPixel4Gray:
+// plane0 <- stored bit0, plane1 <- stored bit1); BWR/BWY send plane0 = BW (palette
+// index 1) then plane1 = accent (index 2). Both share the identical byte layout, so
+// stream the bytes to the panel, switching from PLANE_0 to PLANE_1 at the single-plane
+// boundary - no on-device de-interleave or 2bpp frame buffer. directWriteBytesWritten
+// is the running total across both planes, so the compressed and uncompressed paths
+// share this one plane-split implementation.
 static void streamGray4Bytes(const uint8_t* buf, uint32_t len) {
     const uint32_t planeBytes = (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
     uint32_t off = 0;
@@ -1467,7 +1469,7 @@ if (partialCtx.active) cleanup_partial_write_state();
     directWriteWidth = globalConfig.displays[0].pixel_width;
     directWriteHeight = globalConfig.displays[0].pixel_height;
     uint32_t pixels = (uint32_t)directWriteWidth * (uint32_t)directWriteHeight;
-    if (directWriteBitplanes) directWriteTotalBytes = (pixels + 7) / 8;
+    if (directWriteBitplanes) directWriteTotalBytes = 2u * (((uint32_t)directWriteWidth + 7u) / 8u) * directWriteHeight;
     else {
         int bitsPerPixel = getBitsPerPixel();
         if (bitsPerPixel == 4) directWriteTotalBytes = (pixels + 1) / 2;
@@ -1638,7 +1640,7 @@ void handleDirectWriteData(uint8_t* data, uint16_t len) {
             directWriteBytesWritten += bytesToWrite;
         } else
 #endif
-        if (directWriteIsGray4()) {
+        if (directWriteIsGray4() || directWriteBitplanes) {
             streamGray4Bytes(data, bytesToWrite);  // advances directWriteBytesWritten, splits planes
         } else {
             bbepWriteData(&bbep, data, bytesToWrite);
@@ -1695,7 +1697,7 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
         return;
     }
     const bool gray4 = directWriteIsGray4();
-    if (gray4) {
+    if (gray4 || directWriteBitplanes) {
         // Both planes must be present before refresh. Compressed and uncompressed
         // paths stream live as 0x71 chunks, so confirm the full two-plane payload
         // arrived before refreshing stale RAM or committing an etag.
@@ -1921,7 +1923,7 @@ static bool zlib_stream_to_direct_write(const uint8_t* data, uint32_t len, bool 
                 directWriteBytesWritten += (uint32_t)bytesOut;
             } else
 #endif
-            if (directWriteIsGray4()) {
+            if (directWriteIsGray4() || directWriteBitplanes) {
                 uint32_t before = directWriteBytesWritten;
                 streamGray4Bytes(decompressionChunk, (uint32_t)bytesOut);
                 if (directWriteBytesWritten - before != (uint32_t)bytesOut) {


### PR DESCRIPTION
## Problem

On 3-colour panels (BWR / BWY colour schemes), the BLE direct-write path only ever wrote the black/white plane. The red/yellow accent plane was never sent to the controller, so every 3-colour refresh committed a new image on the BW layer while showing whatever stale content was left in the accent RAM.

## Root cause

`handleDirectWriteStart` sized a BWR/BWY upload at a single flat plane (`(pixels + 7) / 8`) and the streamer never issued `bbepStartWrite(&bbep, PLANE_1)`, so the second (accent) plane was dropped. The auto-END fired as soon as one plane's worth of bytes had arrived. This is a regression from the "Big Refactor" (`fd0d73a`), which dropped the plane-switch logic that existed in `5dcb60b`.

All senders (py-opendisplay, website JS) already transmit two concatenated, row-padded 1-bit planes: `plane0` = black/white (palette index 1) then `plane1` = accent (index 2). That is byte-for-byte the same layout the GRAY4 path already streams.

## Fix

Route BWR/BWY through the existing two-plane streamer (`streamGray4Bytes`), which drives the PLANE_0 → PLANE_1 switch off the running `directWriteBytesWritten`:

- **Start size**: size the upload at two row-padded planes (`2 * ((width+7)/8) * height`), matching the gray4 formula. This also makes the compressed decompressed-size check equal the client's 2-plane `uncompressed_size`, fixing the compressed-BWR START NACK for free.
- **Dispatch**: stream bitplanes through the plane-splitter on both the uncompressed and compressed decompress paths.
- **END guard**: extend the "both planes must be present before refresh" check to bitplanes, so a short/one-plane payload errors (`{0xFF, 0x72}`) instead of refreshing stale RAM.
- Updated the `streamGray4Bytes` doc comment to reflect that it now also serves BWR/BWY (identical byte layout).

The change is surgical (13 insertions, 11 deletions in one file); no other colour scheme or the partial-update path is touched. The initial `bbepStartWrite(PLANE_0)` for bitplanes is harmless — `streamGray4Bytes` re-issues `bbepStartWrite(PLANE_0)` at offset 0, exactly as the tolerated gray4 double-start already does.

## Testing

Compiled clean with PlatformIO (no source changes needed beyond this file):

- `pio run -e nrf52840custom` → SUCCESS
- `pio run -e esp32-s3-N16R8` → SUCCESS

Not yet smoke-tested on hardware. This still needs a hardware smoke test on a real BWR/BWY panel (uncompressed and compressed direct-write) to confirm the accent plane now renders — I can't run that here.

## Related

Web-tool counterpart: https://github.com/OpenDisplay/opendisplay.org/pull/26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR