### PR TITLE
fix: validate config CRC with CRC-16/CCITT (advisory) to match toolbox/nRF/Silabs

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -213,6 +213,38 @@ bool hasValidStoredConfig(void) {
     return loadConfig(buf, &len);
 }
 
+static uint16_t crc16_ccitt_feed(uint16_t crc, uint8_t b) {
+    crc ^= (uint16_t)((uint16_t)b << 8);
+    for (int j = 0; j < 8; j++) {
+        if ((crc & 0x8000U) != 0U) {
+            crc = (uint16_t)(((uint32_t)crc << 1) ^ 0x1021U);
+        } else {
+            crc = (uint16_t)((uint32_t)crc << 1);
+        }
+    }
+    return crc;
+}
+
+// CRC-16/CCITT-FALSE over the toolbox-outer config container body (excludes the
+// trailing 2 CRC bytes), with the first two (length) bytes forced to zero so the
+// value is independent of the container length. Matches the canonical helper in
+// OpenDisplay-Firmware_NRF/config_parser.c and OpenDisplay-Firmware_Silabs.
+static uint16_t config_toolbox_outer_crc16(const uint8_t* data, uint32_t body_len) {
+    uint16_t crc = 0xFFFFU;
+    if (body_len < 2U) {
+        for (uint32_t i = 0; i < body_len; i++) {
+            crc = crc16_ccitt_feed(crc, data[i]);
+        }
+        return crc;
+    }
+    crc = crc16_ccitt_feed(crc, 0);
+    crc = crc16_ccitt_feed(crc, 0);
+    for (uint32_t i = 2U; i < body_len; i++) {
+        crc = crc16_ccitt_feed(crc, data[i]);
+    }
+    return crc;
+}
+
 uint32_t calculateConfigCRC(uint8_t* data, uint32_t len){
     uint32_t crc = 0xFFFFFFFF;
     for (uint32_t i = 0; i < len; i++) {
@@ -578,8 +610,9 @@ bool loadGlobalConfig(){
     }
     if (offset < configLen - 2) {
         uint16_t crcGiven = configData[configLen - 2] | (configData[configLen - 1] << 8);
-        uint32_t crcCalculated32 = calculateConfigCRC(configData, configLen - 2);
-        uint16_t crcCalculated = (uint16_t)(crcCalculated32 & 0xFFFF);  // Use lower 16 bits for backwards compatibility
+        // Advisory (warn-only) validation using CRC-16/CCITT to match the toolbox,
+        // nRF and Silabs firmware. Not enforced: a mismatch logs a warning only.
+        uint16_t crcCalculated = config_toolbox_outer_crc16(configData, configLen - 2);
         if (crcGiven != crcCalculated) {
             writeSerial("WARNING: Config CRC mismatch (given: 0x" + String(crcGiven, HEX) + 
                        ", calculated: 0x" + String(crcCalculated, HEX) + ")");


### PR DESCRIPTION
## Problem
The on-wire toolbox-outer config container carries a trailing 2-byte CRC. Across the ecosystem this was validated three different ways. The website/toolbox (which configured most deployed displays), the nRF firmware, and the Silabs firmware all use the canonical **CRC-16/CCITT-FALSE** over the container body with the first two (length) bytes forced to zero. This Arduino firmware was the outlier: it validated with the low 16 bits of a CRC32.

## Decision
Standardize the on-wire config-container CRC on **CRC-16/CCITT**, and keep it **advisory (NOT enforced)** — validation stays warn-only, exactly as it is today: it logs a warning on mismatch and continues parsing. CCITT was chosen because most deployed displays were configured by the website/toolbox, which writes CCITT, and the nRF/Silabs firmware and toolbox already use the canonical CCITT.

## Fix
- Added a static `config_toolbox_outer_crc16(const uint8_t*, uint32_t)` helper in `src/config_parser.cpp` that mirrors the nRF/Silabs implementation byte-for-byte: init `0xFFFF`, poly `0x1021`, MSB-first, no reflection, no final XOR, over `[byte0, byte1, version, ...packets]` with the first two (length) bytes forced to zero, excluding the trailing 2 CRC bytes. Built on a `crc16_ccitt_feed` primitive, matching the reference tree.
- Replaced the `calculateConfigCRC(...) & 0xFFFF` computation at the on-wire validation site with a call to the new helper.
- Behavior stays warn-only: a mismatch logs `WARNING: Config CRC mismatch (...)` and parsing continues. Nothing is rejected.

## Scope note — the internal storage CRC32 is deliberately untouched
There are two distinct CRCs in this repo. Only the on-wire one changed. The internal flash-storage integrity CRC (`calculateConfigCRC`, CRC32) used for the `config_storage_t` wrapper on save/load never leaves the device and is unrelated to the on-wire config — it is left as CRC32, along with both of its call sites.

## Testing
- Verified the helper against ground-truth vectors (body = container without the trailing 2 CRC bytes; helper zeroes bytes 0-1 internally):
  - `00 00 01` → `0xDCBD`
  - `2A 00 01 AA BB` → `0xC239`
  - `[len_lo len_hi] 01 00 01` + fourteen `00` → `0x0D7F` for any length-byte values (proves zeroing).
- Builds green: `pio run -e nrf52840custom` (SUCCESS) and `pio run -e esp32-c3-N4` (SUCCESS).

## Advisory, not enforced
This does not add any rejection path. A CRC mismatch remains a logged warning only; config parsing proceeds regardless.

---
Part of the config-CRC CCITT standardization (MJ-7); companion changes in OpenDisplay/py-opendisplay and OpenDisplay/opendisplay.org. Cross-links to be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR

---
**Related PRs — config-CRC CCITT standardization (finding MJ-7):**
- OpenDisplay/py-opendisplay#117 — Python client `calculate_config_crc` → CCITT
- OpenDisplay/Firmware#83 — Arduino toolbox-outer validation → CCITT (advisory)
- OpenDisplay/opendisplay.org#27 — website `parseConfigBytes` read-back (zero length bytes)

Already canonical (no change): toolbox writer, nRF firmware, Silabs firmware. `opendisplay-js` (TS) intentionally not updated (abandoned).