### PR TITLE
[BREAKING] Fix AES-CCM nonce reuse (direction bit) + exact-counter replay (MJ-12)

### DIFF
--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -42,6 +42,22 @@ bool constantTimeCompare(const uint8_t* a, const uint8_t* b, size_t len);
 void secure_random(uint8_t* output, size_t len);
 void writeSerial(String message, bool newLine = true);
 
+// AES-CCM nonce direction domain separation.
+// The 16-byte full nonce is session_id(8) || counter(8, big-endian); the CCM
+// nonce is nonce_full[3..15], which includes the counter's most-significant
+// byte (nonce[8]). Previously both directions used counters starting at 0, so
+// inbound command #0 and outbound response #0 shared an identical (key, nonce)
+// pair -- a fatal CCM nonce reuse that leaks keystream and forges tags. We now
+// reserve the most-significant bit of the counter field (bit 0x80 of nonce[8])
+// as a direction flag so the two directions can never collide on a nonce:
+//   - inbound  commands  (client -> server): bit MUST be clear
+//   - outbound responses (server -> client): bit is SET
+// The counter never grows large enough to reach this bit in practice.
+// NOTE: this changes the wire crypto and must ship in lockstep with matching
+// changes in py-opendisplay (crypto.py), Firmware_NRF (encryption.c) and
+// Firmware_Silabs, or encrypted comms break with un-updated peers.
+static constexpr uint8_t NONCE_DIRECTION_SERVER = 0x80;
+
 void getAuthDeviceIdBytes(uint8_t* device_id) {
     if (device_id == nullptr) return;
 #ifdef TARGET_NRF
@@ -112,6 +128,13 @@ bool verifyNonceReplay(uint8_t* nonce) {
     uint8_t nonce_session_id[8];
     uint64_t nonce_counter = 0;
     memcpy(nonce_session_id, nonce, 8);
+    // Inbound commands (client -> server) MUST have the direction bit clear.
+    // Responses set NONCE_DIRECTION_SERVER in the counter's high byte; rejecting
+    // it here guarantees the two directions never reuse a (key, nonce) pair.
+    if (nonce[8] & NONCE_DIRECTION_SERVER) {
+        writeSerial("ERROR: Inbound command nonce has server direction bit set (rejected)", true);
+        return false;
+    }
     for (int i = 0; i < 8; i++) {
         nonce_counter = (nonce_counter << 8) | nonce[8 + i];
     }
@@ -133,7 +156,14 @@ bool verifyNonceReplay(uint8_t* nonce) {
         writeSerial(buf, true);
         return false;
     }
-    if (nonce_counter <= encryptionSession.last_seen_counter && counter_diff != 0) {
+    // A legitimate packet always carries a strictly-increasing counter, so any
+    // counter <= last_seen (including an exact match of the current maximum, and
+    // the counter-0 command) must be checked against the replay window. The
+    // previous `&& counter_diff != 0` skipped this check on an exact match,
+    // letting the most-recent command be replayed. The window is initialised to
+    // a sentinel (see clearEncryptionSession/handleAuthenticate) so the genuine
+    // first counter-0 command is not mistaken for a replay of the zero-init.
+    if (nonce_counter <= encryptionSession.last_seen_counter) {
         bool already_seen = false;
         for (int i = 0; i < 64; i++) {
             if (encryptionSession.replay_window[i] == nonce_counter) {
@@ -165,6 +195,9 @@ void getCurrentNonce(uint8_t* nonce) {
     for (int i = 0; i < 8; i++) {
         nonce[8 + i] = (counter >> (56 - i * 8)) & 0xFF;
     }
+    // Set the direction flag for server -> client responses so a response nonce
+    // can never collide with an inbound command nonce sharing the same counter.
+    nonce[8] |= NONCE_DIRECTION_SERVER;
 }
 
 void incrementNonceCounter() {
@@ -198,7 +231,8 @@ void clearEncryptionSession() {
     encryptionSession.last_activity = 0;
     encryptionSession.auth_attempts = 0;
     encryptionSession.server_nonce_time = 0;
-    memset(encryptionSession.replay_window, 0, sizeof(encryptionSession.replay_window));
+    // Sentinel (0xFF..) marks "no counter recorded"; 0 is a valid counter value.
+    memset(encryptionSession.replay_window, 0xFF, sizeof(encryptionSession.replay_window));
     writeSerial("Encryption session cleared");
 }
 
@@ -606,7 +640,8 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
         encryptionSession.integrity_failures = 0;
         encryptionSession.session_start_time = currentTime;
         encryptionSession.last_activity = currentTime;
-        memset(encryptionSession.replay_window, 0, sizeof(encryptionSession.replay_window));
+        // Sentinel (0xFF..) marks "no counter recorded"; 0 is a valid counter value.
+        memset(encryptionSession.replay_window, 0xFF, sizeof(encryptionSession.replay_window));
         memset(encryptionSession.pending_server_nonce, 0, 16);
         encryptionSession.server_nonce_time = 0;
         uint8_t server_response[16];


### PR DESCRIPTION
> ⚠️ **BREAKING — coordinated protocol change. DO NOT MERGE standalone.**

This fixes finding **MJ-12** in `src/encryption.cpp`. It has two parts: one safe replay-guard fix, and one breaking change to the on-wire AES-CCM nonce.

## Part A — safe replay-guard fix (non-breaking, internal state only)
`verifyNonceReplay()` skipped the replay-window scan whenever the incoming counter *exactly equaled* `last_seen_counter` — the `&& counter_diff != 0` guard on the window check. That let the most-recent command (and the counter-0 command) be replayed and re-executed, since an exact-counter match bypassed the "already seen" scan entirely.

Fix: remove the `&& counter_diff != 0` guard so an exact-counter match is scanned against the replay window like any other non-new-maximum counter. A legitimate packet always carries a strictly-increasing counter, so this rejects only replays.

One supporting change is required to keep it correct: the client's first command uses **counter 0** (`py-opendisplay` `_nonce_counter` starts at 0 and increments after encrypting), and the replay window was zero-initialised. Scanning counter 0 against an all-zero window would false-match and reject the genuine first command. So the replay window is now initialised to a `0xFF` sentinel ("no counter recorded") instead of `0`, which is a real counter value. This is internal RAM state only — **no wire/format change.**

## Part B — nonce direction bit (⚠️ BREAKING wire crypto change)
The 16-byte full nonce was `session_id(8) || counter(8, big-endian)` for **both** directions. Both the inbound command counter and the outbound response counter reset to **0** at authentication, so **command #0 and response #0 encrypt under an identical `(key, nonce)` pair.** AES-CCM nonce reuse under the same key is fatal: it leaks the keystream (XOR of the two plaintexts) and enables tag forgery.

Fix: reserve the most-significant bit of the counter field — bit `0x80` of `nonce[8]`, which sits inside the CCM nonce slice `nonce_full[3:16]` — as a **direction flag**:
- inbound commands (client → server): bit MUST be clear; an inbound command with the bit set is now rejected.
- outbound responses (server → client): bit is SET.

This guarantees the two directions can never collide on a nonce. The counter never grows large enough to reach this bit in practice.

**This changes the on-wire crypto.** Updated firmware will not interoperate with an un-updated client, and vice-versa.

## Rollout / lockstep required
Part B must land together with matching nonce-construction changes in **all** peers, or encrypted comms break for un-updated devices/clients:
- **`py-opendisplay`** — `src/opendisplay/crypto.py` (`get_nonce()` / `encrypt_command()` / `decrypt_response()`): as the client it must keep the direction bit **clear** on the command nonces it sends, and set/expect it **set** on the response nonces it decrypts.
- **`Firmware_NRF`** — `encryption.c` (nonce construction + inbound direction-bit check).
- **`Firmware_Silabs`** — equivalent nonce construction + inbound check.

None of those repos are touched by this PR.

**Suggestion:** Part A (the replay-guard fix + sentinel init) is fully backward-compatible and could be split into its own non-breaking PR if the team wants the replay fix shipped ahead of the coordinated Part B rollout.

## Testing
Firmware builds clean with the changes:
- `pio run -e nrf52840custom` → **SUCCESS** (encryption.cpp recompiled + linked)
- `pio run -e esp32-c3-N4` → **SUCCESS** (encryption.cpp recompiled + linked)

No on-device / interop testing performed; Part B interop requires the coordinated peer changes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR
