### PR TITLE
Clear displayed_etag on etag-less full refresh

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1751,7 +1751,13 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
     esp32_restart_ble_advertising();
 #endif
     if (refreshSuccess) {
+        // A successful refresh changed the panel image. Commit the new etag
+        // when the client supplied a valid one; otherwise clear the stale etag
+        // (etag-less full upload / auto-complete) so a later partial update
+        // gets a clean ETAG mismatch and falls back to a full upload instead
+        // of diffing against the wrong, now-outdated base image.
         if (hasNewEtag && newEtag != 0) displayed_etag = newEtag;
+        else displayed_etag = 0;
         uint8_t refreshResponse[] = {0x00, 0x73};
         sendResponse(refreshResponse, sizeof(refreshResponse));
     } else {


### PR DESCRIPTION
## Problem (MJ-17)

`handleDirectWriteEnd` in `src/display_service.cpp` commits `displayed_etag` only inside a `hasNewEtag && newEtag != 0` guard. An etag-less full upload (or an auto-complete END with no etag payload) changes the panel pixels but leaves `displayed_etag` at its previous value.

The partial-update path (`0x76`) validates with:

```cpp
if (oldEtag == 0 || oldEtag != displayed_etag || newEtag == 0) { /* ETAG mismatch -> full fallback */ }
```

So a later partial from another client whose `oldEtag` happens to equal the now-stale `displayed_etag` passes this check and diffs against the wrong, outdated base image — silent visual corruption.

## Fix

On a successful refresh where no valid etag was supplied, clear `displayed_etag` to `0` (invalid/unknown) instead of leaving a stale value. `0` is never a legitimate `displayed_etag` match (a partial with `oldEtag == 0` is already rejected), so the next partial gets a clean ETAG mismatch and correctly falls back to a full upload. No bogus etag is invented; a later client simply re-uploads in full.

Behavior when a real etag IS supplied is unchanged, as is the partial-refresh commit path (`displayed_etag = partialCtx.new_etag` on success).

## State transitions

1. Etag-less full upload succeeds → `displayed_etag = 0`.
2. Next partial (`0x76`) arrives with any `oldEtag` → `oldEtag != displayed_etag (0)` → clean ETAG mismatch NACK.
3. Client falls back to a full upload (supplying a real etag if it has one) → base image is correct again.

Previously step 1 left the old etag in place, so step 2 could false-match and diff against stale pixels.

## Verification

Builds pass:
- `pio run -e nrf52840custom` — SUCCESS
- `pio run -e esp32-s3-N16R8` — SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR