### PR TITLE
Row-pad direct-write sizing for 1/2/4bpp single-plane formats

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1473,10 +1473,16 @@ if (partialCtx.active) cleanup_partial_write_state();
     uint32_t pixels = (uint32_t)directWriteWidth * (uint32_t)directWriteHeight;
     if (directWriteBitplanes) directWriteTotalBytes = (pixels + 7) / 8;
     else {
+        // Panel RAM is row-padded: each row occupies ceil(w / pixelsPerByte) bytes, and the
+        // Python sender row-pads every plane (np.packbits(axis=1)). Size FLAT and we under-count
+        // on width-not-divisible-by-8 panels (e.g. 122-wide EP213), auto-completing before the
+        // bottom rows are written. Size row-padded to match sender + the gray4/bitplane paths.
+        uint32_t w = (uint32_t)directWriteWidth;
+        uint32_t h = (uint32_t)directWriteHeight;
         int bitsPerPixel = getBitsPerPixel();
-        if (bitsPerPixel == 4) directWriteTotalBytes = (pixels + 1) / 2;
-        else if (bitsPerPixel == 2) directWriteTotalBytes = (pixels + 3) / 4;
-        else directWriteTotalBytes = (pixels + 7) / 8;
+        if (bitsPerPixel == 4) directWriteTotalBytes = ((w + 1u) / 2u) * h;       // ceil(w/2) bytes/row
+        else if (bitsPerPixel == 2) directWriteTotalBytes = ((w + 3u) / 4u) * h;  // ceil(w/4) bytes/row
+        else directWriteTotalBytes = calc_controller_plane_bytes(directWriteWidth, directWriteHeight); // ceil(w/8) bytes/row
     }
     // 4-gray arrives as two concatenated 1bpp planes (plane0 ++ plane1), streamed to
     // PLANE_0/PLANE_1. Both compressed and uncompressed transports feed bytes through


### PR DESCRIPTION
## Problem

For direct-write uploads, the firmware sizes non-plane formats **FLAT** in `handleDirectWriteStart` (`src/display_service.cpp`): `(pixels+7)/8` (1bpp), `(pixels+3)/4` (2bpp), `(pixels+1)/2` (4bpp), where `pixels = w * h`.

But panel RAM is **row-padded**: each row occupies `ceil(w / pixelsPerByte)` bytes, and the Python sender already row-pads every plane via `np.packbits(axis=1)`. On width-not-divisible-by-8 panels (e.g. the 122-wide EP213) the firmware under-counts the total, so `directWriteBytesWritten >= directWriteTotalBytes` trips early, the write auto-completes, and the bottom rows are never written.

## Fix

Size the 1bpp/2bpp/4bpp single-plane totals **row-padded** — `bytesPerRow * height`:

- 1bpp: `ceil(w/8)` bytes/row (reuses the existing `calc_controller_plane_bytes` helper)
- 2bpp: `ceil(w/4)` bytes/row
- 4bpp: `ceil(w/2)` bytes/row

This matches both the Python sender and the panel controller's `SetAddrWindow(0,0,w,h)` + `WriteData` pitch — the same per-row padding the gray4 and BWR/BWY bitplane paths already use (those were made row-padded in #82 and are **not** touched here).

For widths divisible by 8 the computed total is identical to before, so mainstream panels are unaffected.

The website counterpart PR row-pads the web upload tool — companion change.

## Testing

- Builds clean: `pio run -e nrf52840custom` (nRF52840) and `pio run -e esp32-c3-N4` (ESP32) both SUCCESS.
- Still needs a smoke test on a real odd-width panel (e.g. 122-wide EP213) to confirm the bottom rows now render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR

---
**Companion PR:** OpenDisplay/opendisplay.org#30 (web-tool row-padding for mono/2bpp/4bpp). Python already row-pads. All three senders + firmware now agree on row-padded sizing.