### PR TITLE
Fix MJ-14 config-read chunk cap + encrypted-response 255 B guard + EP368 boot 4-gray LUT

### DIFF
--- a/src/boot_screen.cpp
+++ b/src/boot_screen.cpp
@@ -532,7 +532,9 @@ static const uint8_t kGray4StoredBase[4] = {3, 1, 2, 0};
 static const uint8_t kGray4StoredV2[4]  = {3, 2, 1, 0};
 
 static bool bootGray4PanelUsesLutV2(uint16_t panelIc) {
-    return panelIc == 0x0028;  // EP426_800x480_4GRAY (u8Colors_4gray_v2)
+    // u8Colors_4gray_v2 panels (mirrors _GRAY4_CODES_BY_PANEL in display_palettes.py):
+    // 0x0028 EP426_800x480_4GRAY and 0x0048 EP368_792x528_4GRAY.
+    return panelIc == 0x0028 || panelIc == 0x0048;
 }
 
 static void bootGray4FillSwatchCodes(uint16_t panelIc, uint8_t out[4]) {

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -324,7 +324,10 @@ void handleReadConfig() {
         uint32_t remaining = configLen;
         uint32_t offset = 0;
         uint16_t chunkNumber = 0;
-        const uint16_t maxChunks = 10;
+        // Cover the full MAX_CONFIG_SIZE. Worst-case per-chunk payload is 94 B
+        // (chunk 0 also carries the 2-byte total-length header; later chunks
+        // carry 96), so ceil(MAX_CONFIG_SIZE / 94) chunks always sends it all.
+        const uint16_t maxChunks = (MAX_CONFIG_SIZE + 93) / 94;
         while (remaining > 0 && chunkNumber < maxChunks) {
             uint16_t responseLen = 0;
             configReadResponseBuffer[responseLen++] = 0x00;

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -693,6 +693,15 @@ bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* cipher
     uint8_t ad[2] = {plaintext[0], plaintext[1]};
     static uint8_t payload_with_length[513];
     uint16_t payload_len = plaintext_len - 2;
+    // The inner length prefix is a single byte, so the payload must be <= 255 B.
+    // The client (py-opendisplay crypto.decrypt_response) reads a 1-byte length,
+    // and the command direction is 1-byte too, so the wire framing must stay
+    // 1-byte. No response reaches 255 B today; refuse rather than silently wrap
+    // if one ever would.
+    if (payload_len > 255) {
+        writeSerial("ERROR: Encrypted response payload exceeds 255 bytes");
+        return false;
+    }
     payload_with_length[0] = payload_len & 0xFF;
     if (payload_len > 0) memcpy(payload_with_length + 1, plaintext + 2, payload_len);
     uint16_t total_payload_len = 1 + payload_len;


### PR DESCRIPTION
Batch of independent Arduino-firmware fixes. Each is surgical; verified with a real nRF52840 and ESP32-S3 build.

### Fixes

- [x] **MJ-14 — config-read chunk cap too small (the live bug).** `handleReadConfig()` in `src/communication.cpp` capped reads at a fixed `maxChunks = 10`. Per-chunk payload is 94 B for chunk 0 (it carries the 2-byte total-length header) and 96 B afterwards, so 10 chunks = 94 + 9×96 = **958 B max readable config**. But Arduino config storage is `MAX_CONFIG_SIZE = 4096` (`src/config_parser.h`). A large config (WiFi + security + data_extended + several instances) exceeds 958 B, so the tail was never sent and the client looped/timed out. Raised the cap to `ceil(MAX_CONFIG_SIZE / 94) = 44` chunks → **new max readable ≈ 4222 B** (94 + 43×96), covering the full 4096. Per-chunk size and framing unchanged.
  - **Old max: 958 B → New max: ~4222 B** (covers `MAX_CONFIG_SIZE` = 4096).
  - nRF/Silabs use 512-byte config storage, so they were unaffected; this is Arduino-only.

- [x] **`encryptResponse` 255-byte inner-length guard (no wire change).** `src/encryption.cpp` stores the encrypted-payload length as a single byte (`payload_with_length[0] = payload_len & 0xFF`), which would silently wrap for responses > 255 B. The 1-byte framing **must stay** to interoperate with the client — `py-opendisplay` `crypto.decrypt_response` reads a 1-byte length, and the command direction is 1-byte too — so widening it would corrupt every encrypted response. Instead, kept the 1-byte prefix and added a guard that refuses (returns `false`, falling back to the existing unencrypted error path) any response whose payload would exceed 255 B, so it can never silently wrap. Latent today (no current response exceeds 255 B); hardening only, **no on-wire framing change**.

- [x] **Boot 4-gray V2 LUT missing EP368 (0x0048).** `bootGray4PanelUsesLutV2()` in `src/boot_screen.cpp` only listed panel `0x0028`, but `display_palettes.py` (`_GRAY4_CODES_BY_PANEL`) assigns the V2 code table to both `0x0028` (EP426) and `0x0048` (EP368). Added `0x0048` so mid-grays aren't swapped on EP368 at boot.

### Deliberately skipped — needs design review

- **M6 "TLV per-packet length" hardening: not actioned.** The config wire format has **no per-packet length field** (that absence is the root of MJ-8), so the proposed "validate TLV per-packet length" change has no field to validate and the finding is ambiguous. Skipped here; flagging for design review rather than guessing.

### Verification

- `pio run -e nrf52840custom` → **SUCCESS**
- `pio run -e esp32-s3-N16R8` → **SUCCESS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR
