### PR TITLE
Emit identifiable error frames on the direct-write path (MJ-16)

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1366,13 +1366,13 @@ void updatemsdata(){
 void handleDirectWriteCompressedData(uint8_t* data, uint16_t len) {
     if (len > UINT32_MAX - directWriteCompressedReceived) {
         cleanupDirectWriteState(true);
-        uint8_t errorResponse[] = {0xFF, 0xFF};
+        uint8_t errorResponse[] = {0xFF, 0x71};
         sendResponse(errorResponse, sizeof(errorResponse));
         return;
     }
     if (!zlib_stream_to_direct_write(data, len, false)) {
         cleanupDirectWriteState(true);
-        uint8_t errorResponse[] = {0xFF, 0xFF};
+        uint8_t errorResponse[] = {0xFF, 0x71};
         sendResponse(errorResponse, sizeof(errorResponse));
         return;
     }
@@ -1487,7 +1487,7 @@ if (partialCtx.active) cleanup_partial_write_state();
         memcpy(&directWriteDecompressedTotal, data, 4);
         if (directWriteDecompressedTotal != directWriteTotalBytes) {
             cleanupDirectWriteState(false);
-            uint8_t errorResponse[] = {0xFF, 0xFF};
+            uint8_t errorResponse[] = {0xFF, 0x70};
             sendResponse(errorResponse, sizeof(errorResponse));
             return;
         }
@@ -1518,7 +1518,7 @@ if (partialCtx.active) cleanup_partial_write_state();
             uint32_t compressedDataLen = len - 4;
             if (!zlib_stream_to_direct_write(data + 4, compressedDataLen, false)) {
                 cleanupDirectWriteState(false);
-                uint8_t errorResponse[] = {0xFF, 0xFF};
+                uint8_t errorResponse[] = {0xFF, 0x70};
                 sendResponse(errorResponse, sizeof(errorResponse));
                 return;
             }
@@ -1582,7 +1582,7 @@ void handlePartialWriteStart(uint8_t* data, uint16_t len) {
     uint32_t expectedLogicalSize = planeBytes * 2u;
 
     if (expectedLogicalSize == 0) {
-        uint8_t errResponse[] = {0xFF, 0xFF};
+        uint8_t errResponse[] = {0xFF, 0x76};
         sendResponse(errResponse, sizeof(errResponse));
         return;
     }
@@ -1694,7 +1694,7 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
     directWriteStartTime = 0;
     if (directWriteCompressed && !zlib_stream_to_direct_write(nullptr, 0, true)) {
         cleanupDirectWriteState(true);
-        uint8_t errorResponse[] = {0xFF, 0xFF};
+        uint8_t errorResponse[] = {0xFF, 0x72};
         sendResponse(errorResponse, sizeof(errorResponse));
         return;
     }


### PR DESCRIPTION
## What

The compressed direct-write path emitted generic `{0xFF, 0xFF}` error frames, making the failing command unidentifiable. The published spec says error frames are `0xFF` followed by the command code (`{0xFF, cmd}`). This makes the firmware conform: the second byte now carries the failing command's low byte, so the frame identifies which command failed. This matches the already-present `{0xFF, 0x72}` gray4-END frame in the same file.

## Sites changed (`src/display_service.cpp`)

| Handler | Failure | New frame | Command |
|---|---|---|---|
| `handleDirectWriteCompressedData` | length-overflow guard | `{0xFF, 0x71}` | DATA |
| `handleDirectWriteCompressedData` | zlib-stream failure | `{0xFF, 0x71}` | DATA |
| `handleDirectWriteStart` | decompressed-size mismatch | `{0xFF, 0x70}` | START |
| `handleDirectWriteStart` | initial zlib-stream failure | `{0xFF, 0x70}` | START |
| `handlePartialWriteStart` | zero logical-size guard | `{0xFF, 0x76}` | PARTIAL START |
| `handleDirectWriteEnd` | compressed final-flush failure | `{0xFF, 0x72}` | END |

Frames stay 2 bytes; only the second byte changed. No `{0xFF, 0xFF}` emissions remain in the file.

## Backward compatibility

Pairs with py-opendisplay PR #120. Its `is_compressed_failure_frame()` accepts both `{0xFF, 0xFF}` and the spec-conformant `{0xFF, 0x70}`, so the compressed-START fallback keeps working regardless of which frame the firmware sends. The DATA/END/partial frames were never valid ACKs, so updated clients raise the same typed protocol error as before — now with the command identified. The website direct-write handler (PR #28) treats any leading-`0xFF` frame as an error.

## Testing

- `pio run -e nrf52840custom` — SUCCESS
- `pio run -e esp32-c3-N4` — SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR