### PR TITLE
SEEED deep-sleep wake TCON re-init + quiet image-write logging

### DIFF
--- a/docs/FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md
+++ b/docs/FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md
@@ -31,7 +31,64 @@ panics, `esp_restart()`, and brownout resets — only true power loss clears it.
 "wake detected correctly + boot screen later" is fully self-consistent with a
 mid-cycle crash.
 
-## Reset sources found in the wake cycle (ranked)
+## UPDATE 2026-07-07 (evening): confirmed by device log — it is a PANIC
+
+Serial capture from the device (Seeed reTerminal E1001, ESP32-S3, bb_epaper
+panel IC 0x3b, no power latch, `power_mode=1`, `deep_sleep_time=180s`):
+
+```
+rst:0x5 (DSLEEP) ... Reset reason: DEEPSLEEP (8)
+=== WOKE FROM DEEP SLEEP ===   Wake-up reason: 4 (TIMER)   Deep sleep count: 2
+=== Minimal Setup (Deep Sleep Wake) ===
+... full config summary ...  Encryption session cleared
+rst:0xc (RTC_SW_CPU_RST)  Saved PC:0x403830d1 ... Reset reason: PANIC (4)
+=== NORMAL BOOT ===   Deep sleep count (RTC): 0
+... boot screen redraws ...
+```
+
+**Confirmed:** the boot-screen reload is a **PANIC that fires inside
+`minimalSetup()` on the deep-sleep wake path, before BLE advertising and
+before any client connection.** The subsequent `RTC_SW_CPU_RST` is a software
+reset (panic reboot), which clears the wake cause -> next boot takes the
+`NORMAL BOOT` branch -> `initDisplay()` -> boot screen. RTC survived
+(consistent with a soft reset, not power loss).
+
+Crash PC `0x403830d1` decodes (xtensa-esp32s3 addr2line, IRAM address stable
+across all S3 builds) to FreeRTOS **`prvCopyDataToQueue`** — i.e. a fault
+inside `xQueueGenericSend`, meaning a driver was invoked with a bad /
+uninstalled queue handle.
+
+### This DISPROVES the ranked hypotheses below
+
+Sources #1, #2, #3, #5 all require an active/last BLE connection or a
+command; the crash happens in `minimalSetup()` *before* BLE is even
+initialized, so those are not the cause of this failure. They remain valid
+latent robustness issues but are not this bug. The real fault is a queue-send
+crash during the wake-path init sequence (`full_config_init` ->
+`initio` -> `ble_init_esp32(true)`).
+
+### Why the exact call is not yet visible
+
+The device logs over `OPENDISPLAY_LOG_UART` (UART1). The IDF panic handler
+only flushes the **console** UART (UART0/USB), so the last buffered lines on
+UART1 before the panic are lost — every capture truncates at
+`Encryption session cleared` (inside `full_config_init`), which is *not*
+necessarily where it died.
+
+### Diagnostic added (commit b6f1da9)
+
+`flushLog()` (blocks until the log UART physically drains) plus flushed
+bracket markers around the three `minimalSetup` stages and `initio`'s
+internal stages (`[wake] >> ...`, `[initio] >> ...`). The next capture's
+last `>>` marker names the faulting call directly. **Next step: flash,
+trigger one wake cycle, capture the log, read the last marker.**
+
+Note (reasoning): `initDisplay()` runs *after* `initio()` on normal boot, and
+the boot screen visibly redraws — so `initio()` itself likely survives, which
+points at `ble_init_esp32(true)` (heavy FreeRTOS-queue user). The markers will
+confirm or refute this.
+
+## Reset sources found in the wake cycle (ranked — see UPDATE above; #1/#2/#3/#5 disproven for THIS log)
 
 ### 1. `BLEDevice::deinit(true)` while a client is connected — `main.cpp:296`
 

--- a/docs/FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md
+++ b/docs/FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md
@@ -1,0 +1,135 @@
+# Findings: Boot screen reloads on deep-sleep wake cycle (ESP32, bb_epaper path)
+
+**Date:** 2026-07-07
+**Symptom:** Device on battery enters timer deep sleep; the wake cycle causes the boot
+screen (logo + QR) to reload on the e-paper panel.
+**Observed:** Serial log shows `=== WOKE FROM DEEP SLEEP ===` on wake, so wake-cause
+detection works. Device uses the bb_epaper driver path (not Seeed_GFX).
+
+## The invariant
+
+`writeBootScreenWithQr()` has exactly one reachable call chain on the bb_epaper path:
+
+```
+setup() [NORMAL BOOT branch only]  (main.cpp:65)
+  -> initDisplay()                 (display_service.cpp:1127)
+    -> refreshBootScreenFull()     (display_service.cpp:154)
+      -> writeBootScreenWithQr()
+```
+
+The deep-sleep wake branch (`minimalSetup()` -> loop -> `fullSetupAfterConnection()`)
+never draws the boot screen. Neither do the BLE callbacks, `reloadConfigAfterSave()`,
+or any command handler.
+
+**Therefore: boot screen appearing == the chip took a second reset whose wake-cause
+reads `ESP_SLEEP_WAKEUP_UNDEFINED`** — a hidden reset (panic, watchdog, brownout, or
+`esp_restart()`) somewhere inside the wake cycle. The `WOKE FROM DEEP SLEEP` log line
+is the wake itself; the boot screen comes from a later reset in the same cycle.
+
+Note: RTC memory (`deep_sleep_count`, `displayed_etag`, `main.h:286-295`) **survives**
+panics, `esp_restart()`, and brownout resets — only true power loss clears it. So
+"wake detected correctly + boot screen later" is fully self-consistent with a
+mid-cycle crash.
+
+## Reset sources found in the wake cycle (ranked)
+
+### 1. `BLEDevice::deinit(true)` while a client is connected — `main.cpp:296`
+
+Command `0x0052` (`handleDeepSleepCommand`, `device_control.cpp:691-701`) calls
+`enterDeepSleep()` **directly from BLE command context with the phone still
+connected**, and the non-DFF branch sends *no response first*. `enterDeepSleep()`
+stops advertising and calls `BLEDevice::deinit(true)` on a live connection — a
+classic Bluedroid panic source (builds use pioarduino / arduino-esp32 3.x, Bluedroid
+by default). Panic -> reboot -> `NORMAL BOOT` -> boot screen.
+
+If the companion app sends `0x0052` at the end of each session, this fires **every
+cycle** — deterministic, matching the symptom.
+
+### 2. Same deinit racing an incoming reconnection
+
+After an image push, `esp32_restart_ble_advertising()` runs
+(`display_service.cpp:1759`); on disconnect the loop then hits `enterDeepSleep()`
+(`main.cpp:197-198`). A phone that auto-reconnects the moment advertising reappears
+can be mid-connection when deinit runs. Same crash, intermittent flavor. Also applies
+when the 10 s advertising timeout (`main.cpp:98-101`) fires just as a connection is
+being established.
+
+### 3. Deep sleep entered with WiFi still running — `main.cpp:275-306`
+
+`fullSetupAfterConnection()` calls `initWiFi(false)` -> `WiFi.begin()` on every
+wake+connect (`wifi_service.cpp:113`), but `enterDeepSleep()` never calls
+`WiFi.disconnect()` / `esp_wifi_stop()` — it only deinits BLE. Sleeping with the WiFi
+driver mid-association is undefined/crash-prone, and also wastes sleep current.
+
+### 4. Brownout on battery
+
+Worst-case concurrent load in the wake cycle: BLE connected + WiFi STA associating +
+EPD rail up + full refresh (`pwrmgm(true)` at `display_service.cpp:1510`). Brownout
+reset -> `NORMAL BOOT` -> boot screen full refresh -> another current spike -> can
+repeat. Log signature: `Brownout detector was triggered` on UART.
+
+### 5. App-sent reboot / OTA command
+
+`0x000F` (`communication.cpp:565-568`) or the OTA command (`device_control.cpp:687`)
+-> `esp_restart()`. Log signature: `=== Reboot COMMAND (0x000F) ===`.
+
+### 6. `checkResetPin()` false-trigger — runs on every wake
+
+`full_config_init()` -> `checkResetPin()` (`config_parser.cpp:841` ->
+`encryption.cpp:797`). If `SECURITY_FLAG_RESET_PIN_ENABLED` is set with neither pull
+flag, the pin is read floating 100 ms after a deep-sleep wake (GPIO state differs
+from cold boot) -> random `secureEraseConfig()` + `reboot()`. Destructive (erases
+config). Log signature: `Reset pin triggered!`.
+
+## Related wake-path defects (not the boot screen, but real)
+
+- **Missing rotation after wake:** `fullSetupAfterConnection()` (`main.cpp:266-271`)
+  does `memset(&bbep)` + `bbepSetPanelType` but **omits `bbepSetRotation`**, which
+  `initDisplay()` sets (`display_service.cpp:1164`). On rotated-panel configs, every
+  post-wake direct write runs with rotation 0 -> misaddressed window -> garbled
+  render or BUSY-stall -> refresh timeout (`0x74`) — which an app may "recover" from
+  by sending reboot, producing the boot screen via source #5.
+
+## Ruled out
+
+- `waitforrefresh()` and the partial path are watchdog-safe (all polling yields via
+  `delay()`).
+- `partial_prepare_panel_ram()` white-fills both planes
+  (`display_service.cpp:2038-2039`), so the RTC-persisted `displayed_etag` matched
+  against power-cycled panel RAM is safe by design.
+- `powerDownAXP2101()` deliberately keeps DC1 (MCU rail) enabled
+  (`display_service.cpp:978`) — not a rail-collapse source.
+- `ble_init_esp32(true)` in minimal mode creates the full GATT server, so connection
+  detection after wake works.
+- Command queue sizes are consistent (`MAX_COMMAND_SIZE` 512 == queue slot size).
+
+## Decisive diagnostic
+
+The firmware logs wake cause but never **reset reason**. Add at the top of `setup()`:
+
+```c
+writeSerial("Reset reason: " + String((int)esp_reset_reason()));
+```
+
+The next boot-screen event identifies the culprit directly:
+
+| `esp_reset_reason()`              | Hypothesis confirmed        |
+|-----------------------------------|-----------------------------|
+| `ESP_RST_PANIC`                   | #1 / #2 / #3 (crash)        |
+| `ESP_RST_BROWNOUT`                | #4                          |
+| `ESP_RST_SW`                      | #5 / #6 (`esp_restart()`)   |
+| `ESP_RST_TASK_WDT` / `ESP_RST_INT_WDT` | watchdog               |
+| `ESP_RST_POWERON`                 | latch/rail power drop       |
+
+Also log `deep_sleep_count` continuity: if it keeps climbing across boot-screen
+events, RTC survived — confirming a soft reset rather than power loss.
+
+## Recommended fixes (once trigger confirmed)
+
+1. In `handleDeepSleepCommand()`: send the ACK, then **disconnect the client and wait
+   for disconnect** before calling `enterDeepSleep()`.
+2. In `enterDeepSleep()`: stop WiFi (`WiFi.disconnect(true); WiFi.mode(WIFI_OFF);`)
+   before BLE deinit.
+3. In `fullSetupAfterConnection()`: add
+   `bbepSetRotation(&bbep, globalConfig.displays[0].rotation * 90);`.
+4. Add permanent `esp_reset_reason()` logging at boot (diagnostic above).

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -81,7 +81,7 @@ static void send_wifi_lan_frame(const uint8_t* payload, uint16_t len) {
 }
 
 /** Mirror responses to BLE only when a central is connected; LAN already got send_wifi_lan_frame. */
-static void esp32_queue_ble_notify_copy(const uint8_t* response, uint16_t len) {
+static void esp32_queue_ble_notify_copy(const uint8_t* response, uint16_t len, bool quiet = false) {
     if (len > MAX_RESPONSE_SIZE_LOCAL) {
         writeSerial("ERROR: Response too large for queue (" + String(len) + " > " + String(MAX_RESPONSE_SIZE_LOCAL) + ")", true);
         return;
@@ -98,7 +98,7 @@ static void esp32_queue_ble_notify_copy(const uint8_t* response, uint16_t len) {
     responseQueue[responseQueueHead].len = len;
     responseQueue[responseQueueHead].pending = true;
     responseQueueHead = nextHead;
-    writeSerial("ESP32: Response queued (queue size: " + String((responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE_LOCAL) % RESPONSE_QUEUE_SIZE_LOCAL) + ")", true);
+    if (!quiet) writeSerial("ESP32: Response queued (queue size: " + String((responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE_LOCAL) % RESPONSE_QUEUE_SIZE_LOCAL) + ")", true);
 }
 #endif
 
@@ -159,6 +159,11 @@ void sendResponseUnencrypted(uint8_t* response, uint16_t len) {
 void sendResponse(uint8_t* response, uint16_t len) {
     static uint8_t encrypted_response[600];
     uint8_t errorResponse[3];
+    // Suppress the 4-line dump for the per-frame 0x0071 image-write ack once the
+    // stream is past its first chunk (chunk 1's ack still logs). Computed before
+    // `response` is swapped to the encrypted buffer. Errors/NACKs start with 0xFF
+    // and never match, so they always log.
+    const bool quietAck = (len == 2 && response[0] == 0x00 && response[1] == 0x71 && imageWriteLogQuietAck());
     if (isAuthenticated() && len >= 2) {
         uint16_t command = (response[0] << 8) | response[1];
         uint8_t status = (len >= 3) ? response[2] : 0x00;
@@ -169,9 +174,11 @@ void sendResponse(uint8_t* response, uint16_t len) {
             uint8_t auth_tag[12];
             uint16_t encrypted_len = 0;
             if (encryptResponse(response, len, encrypted_response, &encrypted_len, nonce, auth_tag)) {
-                writeSerial("Sending encrypted response:", true);
-                writeSerial("  Original length: " + String(len) + " bytes", true);
-                writeSerial("  Encrypted length: " + String(encrypted_len) + " bytes", true);
+                if (!quietAck) {
+                    writeSerial("Sending encrypted response:", true);
+                    writeSerial("  Original length: " + String(len) + " bytes", true);
+                    writeSerial("  Encrypted length: " + String(encrypted_len) + " bytes", true);
+                }
                 response = encrypted_response;
                 len = encrypted_len;
             } else {
@@ -182,37 +189,41 @@ void sendResponse(uint8_t* response, uint16_t len) {
                 response = errorResponse;
                 len = sizeof(errorResponse);
             }
-        } else {
+        } else if (!quietAck) {
             writeSerial("Sending unencrypted response (authentication/firmware version/error)", true);
         }
     }
 
-    writeSerial("Sending response:", true);
-    writeSerial("  Length: " + String(len) + " bytes", true);
-    writeSerial("  Command: 0x" + String(response[0], HEX) + String(response[1], HEX), true);
-    String hexDump = "  Full command: ";
-    for (int i = 0; i < len && i < 32; i++) {
-        if (i > 0) hexDump += " ";
-        if (response[i] < 16) hexDump += "0";
-        hexDump += String(response[i], HEX);
+    if (!quietAck) {
+        writeSerial("Sending response:", true);
+        writeSerial("  Length: " + String(len) + " bytes", true);
+        writeSerial("  Command: 0x" + String(response[0], HEX) + String(response[1], HEX), true);
+        String hexDump = "  Full command: ";
+        for (int i = 0; i < len && i < 32; i++) {
+            if (i > 0) hexDump += " ";
+            if (response[i] < 16) hexDump += "0";
+            hexDump += String(response[i], HEX);
+        }
+        if (len > 32) hexDump += " ...";
+        writeSerial(hexDump, true);
     }
-    if (len > 32) hexDump += " ...";
-    writeSerial(hexDump, true);
 #ifdef TARGET_ESP32
     send_wifi_lan_frame(response, len);
-    esp32_queue_ble_notify_copy(response, len);
+    esp32_queue_ble_notify_copy(response, len, quietAck);
 #endif
 #ifdef TARGET_NRF
     if (Bluefruit.connected() && imageCharacteristic.notifyEnabled()) {
-        String nrfHexDump = "NRF: Sending response: ";
-        for (int i = 0; i < len && i < 32; i++) {
-            if (i > 0) nrfHexDump += " ";
-            if (response[i] < 16) nrfHexDump += "0";
-            nrfHexDump += String(response[i], HEX);
+        if (!quietAck) {
+            String nrfHexDump = "NRF: Sending response: ";
+            for (int i = 0; i < len && i < 32; i++) {
+                if (i > 0) nrfHexDump += " ";
+                if (response[i] < 16) nrfHexDump += "0";
+                nrfHexDump += String(response[i], HEX);
+            }
+            if (len > 32) nrfHexDump += "...";
+            writeSerial(nrfHexDump, true);
+            writeSerial("NRF: BLE notification sent (" + String(len) + " bytes)", true);
         }
-        if (len > 32) nrfHexDump += "...";
-        writeSerial(nrfHexDump, true);
-        writeSerial("NRF: BLE notification sent (" + String(len) + " bytes)", true);
         imageCharacteristic.notify(response, len);
         delay(20);
     } else {
@@ -477,7 +488,10 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
     }
 
     uint16_t command = (data[0] << 8) | data[1];
-    writeSerial("Processing command: 0x" + String(command, HEX));
+    // Silence the per-frame command spam for image-write data (0x0071) once the
+    // stream is past its first chunk; the display handler's 5% meter reports it.
+    const bool quietCmd = (command == 0x0071) && imageWriteLogQuietCmd();
+    if (!quietCmd) writeSerial("Processing command: 0x" + String(command, HEX));
 
     if (command == 0x0050) {
         writeSerial("=== AUTHENTICATE COMMAND (0x0050) ===");
@@ -516,17 +530,19 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
 
         uint16_t encrypted_data_len = len - 2 - 16 - 12;
 
-        static char data_buf[256];
-        snprintf(data_buf, sizeof(data_buf), "Encrypted command: len=%u, command=0x%04X, encrypted_data_len=%u",
-                 (unsigned int)len, (unsigned int)command, (unsigned int)encrypted_data_len);
-        writeSerial(data_buf);
-        static char nonce_buf[64];
-        snprintf(nonce_buf, sizeof(nonce_buf), "Full nonce: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
-                 nonce_full[0], nonce_full[1], nonce_full[2], nonce_full[3],
-                 nonce_full[4], nonce_full[5], nonce_full[6], nonce_full[7],
-                 nonce_full[8], nonce_full[9], nonce_full[10], nonce_full[11],
-                 nonce_full[12], nonce_full[13], nonce_full[14], nonce_full[15]);
-        writeSerial(nonce_buf);
+        if (!quietCmd) {
+            static char data_buf[256];
+            snprintf(data_buf, sizeof(data_buf), "Encrypted command: len=%u, command=0x%04X, encrypted_data_len=%u",
+                     (unsigned int)len, (unsigned int)command, (unsigned int)encrypted_data_len);
+            writeSerial(data_buf);
+            static char nonce_buf[64];
+            snprintf(nonce_buf, sizeof(nonce_buf), "Full nonce: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+                     nonce_full[0], nonce_full[1], nonce_full[2], nonce_full[3],
+                     nonce_full[4], nonce_full[5], nonce_full[6], nonce_full[7],
+                     nonce_full[8], nonce_full[9], nonce_full[10], nonce_full[11],
+                     nonce_full[12], nonce_full[13], nonce_full[14], nonce_full[15]);
+            writeSerial(nonce_buf);
+        }
 
         if (!decryptCommand(data + 2 + 16, encrypted_data_len, plaintext, &plaintext_len, nonce_full, auth_tag, command)) {
             writeSerial("ERROR: Decryption failed");
@@ -613,5 +629,5 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             writeSerial("Expected: 0x0011 (read config), 0x0064 (image info), 0x0065 (block data), or 0x0003 (finalize)");
             break;
     }
-    writeSerial("Command processing completed successfully");
+    if (!quietCmd) writeSerial("Command processing completed successfully");
 }

--- a/src/display_seeed_gfx.cpp
+++ b/src/display_seeed_gfx.cpp
@@ -74,6 +74,10 @@ void opendisplay_seeed_gfx_load_pins_from_display(const struct DisplayConfig* d,
 
 static EPaper g_seeed_epaper;
 static uint32_t seeed_direct_offset;
+// Plain RAM (deliberately NOT RTC_DATA_ATTR): false after every reset, including
+// deep-sleep wake — which is exactly when the power-cycled IT8951 TCON needs a full
+// begin()/hostTconInit() rather than a cheap wake(). Set true once fully inited per boot.
+static bool seeed_gfx_hw_initialized = false;
 
 static bool seeed_gfx_panel_is_4gray(void) {
     if (globalConfig.display_count < 1) return false;
@@ -109,6 +113,7 @@ void seeed_gfx_epaper_begin(void) {
         }
     }
     g_seeed_epaper.begin(0);
+    seeed_gfx_hw_initialized = true;
 }
 
 void seeed_gfx_full_update(void) {
@@ -139,7 +144,18 @@ void seeed_gfx_boot_skip_planes(void) {
 
 void seeed_gfx_direct_write_reset(void) {
     seeed_gfx_prepare_hardware();
-    g_seeed_epaper.wake();
+    if (!seeed_gfx_hw_initialized) {
+        // First render this boot (cold boot before any boot-screen init, or — the case
+        // this fixes — the first push after a deep-sleep wake): the IT8951 TCON was
+        // power-cycled, so a full begin() is required. hostTconInit() reprograms VCOM,
+        // panel dimensions, and I80CPCR packed-pixel mode; wake() alone only sends
+        // tconWake() and would leave the TCON unconfigured (garbled/blank first refresh
+        // or a busy stall). seeed_gfx_epaper_begin() also restores the correct gray-mode
+        // sprite and sets seeed_gfx_hw_initialized = true.
+        seeed_gfx_epaper_begin();
+    } else {
+        g_seeed_epaper.wake();
+    }
     seeed_direct_offset = 0;
     void* p = g_seeed_epaper.getPointer();
     if (p) {

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -1370,6 +1370,99 @@ void updatemsdata(){
     mloopcounter &= 0x0F;
 }
 
+// --- Quiet image-write logging ---------------------------------------------
+// An image push arrives as a 0x70 start, many 0x71 data frames, and a 0x72 end.
+// Logging every frame + its ack floods the UART (~1 MB of text for a 1.3 MB
+// image) and, once the TX buffer fills, throttles the transfer itself. Instead
+// we log the first frame in full, a 5%-step percentage meter thereafter, and
+// the final frame + chunk total at completion. imageWriteLogQuiet{Cmd,Ack}()
+// let communication.cpp suppress the per-frame command/ack spam accordingly.
+static uint32_t imgLogTotalBytes;    // expected payload for this stream
+static uint32_t imgLogChunks;        // 0x71 frames seen this stream
+static uint8_t  imgLogLastStep;      // last 5% step printed (pct/5)
+static uint16_t imgLogLastLen;       // length of most recent frame
+static uint8_t  imgLogLastHead[16];  // first bytes of most recent frame
+static uint8_t  imgLogLastHeadLen;   // valid bytes in imgLogLastHead
+static uint32_t imgLogStartMs;       // millis() at stream start (for throughput)
+
+static String imgLogHex(const uint8_t* buf, uint8_t n) {
+    String s;
+    for (uint8_t i = 0; i < n; i++) {
+        if (i > 0) s += " ";
+        if (buf[i] < 16) s += "0";
+        s += String(buf[i], HEX);
+    }
+    return s;
+}
+
+static void imageWriteLogReset(void) {
+    imgLogTotalBytes = 0;
+    imgLogChunks = 0;
+    imgLogLastStep = 0;
+    imgLogLastLen = 0;
+    imgLogLastHeadLen = 0;
+    imgLogStartMs = 0;
+}
+
+static void imageWriteLogStart(uint32_t totalBytes) {
+    imgLogTotalBytes = totalBytes;
+    imgLogStartMs = millis();
+    writeSerial("DW start: " + String(totalBytes) + " bytes expected", true);
+}
+
+static void imageWriteLogChunk(const uint8_t* data, uint16_t len) {
+    imgLogChunks++;
+    imgLogLastLen = len;
+    imgLogLastHeadLen = (len < sizeof(imgLogLastHead)) ? (uint8_t)len : (uint8_t)sizeof(imgLogLastHead);
+    memcpy(imgLogLastHead, data, imgLogLastHeadLen);
+    if (imgLogChunks == 1) {
+        writeSerial("DW frame 1: " + String(len) + " bytes: " + imgLogHex(imgLogLastHead, imgLogLastHeadLen), true);
+        if (len > 0 && imgLogTotalBytes > 0) {
+            uint32_t est = (imgLogTotalBytes + len - 1) / len;
+            writeSerial("DW expecting ~" + String(est) + " chunks", true);
+        }
+    }
+}
+
+static void imageWriteLogProgress(uint32_t written, uint32_t total) {
+    if (total == 0) return;
+    uint32_t pct = (uint64_t)written * 100u / total;
+    if (pct >= 100) return;                 // completion summary covers 100%
+    uint8_t step = (uint8_t)(pct / 5u);
+    if (step <= imgLogLastStep) return;
+    imgLogLastStep = step;
+    writeSerial("DW " + String(pct) + "% (" + String(imgLogChunks) + " chunks, " +
+                String(written) + "/" + String(total) + " bytes)", true);
+}
+
+static void imageWriteLogFinish(uint32_t written, uint32_t total) {
+    writeSerial("DW final frame " + String(imgLogChunks) + ": " + String(imgLogLastLen) +
+                " bytes: " + imgLogHex(imgLogLastHead, imgLogLastHeadLen), true);
+    uint32_t elapsedMs = millis() - imgLogStartMs;   // unsigned wrap-safe over one stream
+    String rate = "n/a";
+    if (elapsedMs > 0) rate = String((float)written / 1.024f / (float)elapsedMs, 1);  // bytes/ms /1.024 = KB/s
+    writeSerial("DW complete: " + String(imgLogChunks) + " chunks, " +
+                String(written) + "/" + String(total) + " bytes, " +
+                String(elapsedMs / 1000.0f, 2) + " s, " + rate + " KB/s", true);
+}
+
+bool imageWriteLogQuietCmd(void) {
+    return (directWriteActive || partialCtx.active) && imgLogChunks >= 1;
+}
+
+bool imageWriteLogQuietAck(void) {
+    return (directWriteActive || partialCtx.active) && imgLogChunks >= 2;
+}
+
+// True when this raw frame is a mid-stream image-write data chunk (command
+// header 0x0071, unencrypted) whose per-frame BLE-receive/queue logging should
+// be suppressed. Lets the receive callback and queue drain in the other files
+// silence their spam without duplicating the stream-state check.
+bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len) {
+    return len >= 2 && data[0] == 0x00 && data[1] == 0x71 && imageWriteLogQuietCmd();
+}
+// ---------------------------------------------------------------------------
+
 void handleDirectWriteCompressedData(uint8_t* data, uint16_t len) {
     if (len > UINT32_MAX - directWriteCompressedReceived) {
         cleanupDirectWriteState(true);
@@ -1384,6 +1477,7 @@ void handleDirectWriteCompressedData(uint8_t* data, uint16_t len) {
         return;
     }
     directWriteCompressedReceived += len;
+    imageWriteLogProgress(directWriteBytesWritten, directWriteTotalBytes);
     uint8_t ackResponse[] = {0x00, 0x71};
     sendResponse(ackResponse, sizeof(ackResponse));
 }
@@ -1466,6 +1560,7 @@ if (partialCtx.active) cleanup_partial_write_state();
     if (directWriteActive) {
         cleanupDirectWriteState(false);
     }
+    imageWriteLogReset();
     touchSuspendForEpdRefresh();
     directWriteTouchSuspended = true;
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_SEEED_GFX)
@@ -1510,6 +1605,7 @@ if (partialCtx.active) cleanup_partial_write_state();
     directWriteActive = true;
     directWriteBytesWritten = 0;
     directWriteStartTime = millis();
+    imageWriteLogStart(directWriteTotalBytes);
     if (displayPowerState) {
         pwrmgm(false);
         delay(50);
@@ -1547,6 +1643,7 @@ if (partialCtx.active) cleanup_partial_write_state();
 void handlePartialWriteStart(uint8_t* data, uint16_t len) {
     if (directWriteActive) cleanupDirectWriteState(false);
     if (partialCtx.active) cleanup_partial_write_state();
+    imageWriteLogReset();
 
     if (len < 17) {
         send_direct_write_nack(0x76, ERR_PARTIAL_STREAM, false);
@@ -1615,6 +1712,7 @@ void handlePartialWriteStart(uint8_t* data, uint16_t len) {
     partialCtx.plane_size = planeBytes;
     partialCtx.current_plane = 0xFF;
     partialCtx.start_time = millis();
+    imageWriteLogStart(expectedLogicalSize);
 
     partial_prepare_panel_ram();
     if (partialCtx.compressed) od_zlib_stream_reset(expectedLogicalSize);
@@ -1635,15 +1733,18 @@ void handlePartialWriteStart(uint8_t* data, uint16_t len) {
 void handleDirectWriteData(uint8_t* data, uint16_t len) {
     if (partialCtx.active) {
         if (len == 0) return;
+        imageWriteLogChunk(data, len);
         if (!partial_consume_bytes(data, (uint32_t)len)) {
             send_direct_write_nack(0x71, ERR_PARTIAL_STREAM, true);
             return;
         }
+        imageWriteLogProgress(partialCtx.bytes_received, partialCtx.expected_stream_size);
         uint8_t ackResponse[] = {0x00, 0x71};
         sendResponse(ackResponse, sizeof(ackResponse));
         return;
     }
     if (!directWriteActive || len == 0) return;
+    imageWriteLogChunk(data, len);
     if (directWriteCompressed) {
         handleDirectWriteCompressedData(data, len);
         return;
@@ -1664,6 +1765,7 @@ void handleDirectWriteData(uint8_t* data, uint16_t len) {
             directWriteBytesWritten += bytesToWrite;
         }
     }
+    imageWriteLogProgress(directWriteBytesWritten, directWriteTotalBytes);
     if (directWriteBytesWritten >= directWriteTotalBytes) {
         handleDirectWriteEnd(nullptr, 0);
     } else {
@@ -1687,6 +1789,7 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
             send_direct_write_nack(0x72, ERR_PARTIAL_STREAM, true);
             return;
         }
+        imageWriteLogFinish(partialCtx.bytes_received, partialCtx.expected_stream_size);
         uint8_t ackResponse[] = {0x00, 0x72};
         sendResponse(ackResponse, sizeof(ackResponse));
         int refreshMode = REFRESH_PARTIAL;
@@ -1725,6 +1828,7 @@ void handleDirectWriteEnd(uint8_t* data, uint16_t len) {
             return;
         }
     }
+    imageWriteLogFinish(directWriteBytesWritten, directWriteTotalBytes);
     int refreshMode = REFRESH_FULL;
     if (data != nullptr && len >= 1 && data[0] == 1) refreshMode = REFRESH_FAST;
     writeSerial("EPD refresh: ", false);

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -94,6 +94,7 @@ extern BLEService* pService;
 void pwrmgm(bool onoff);
 String getChipIdHex();
 void writeSerial(String message, bool newLine);
+void flushLog();
 void bbepInitIO(BBEPDISP *pBBEP, uint8_t u8DC, uint8_t u8RST, uint8_t u8BUSY, uint8_t u8CS, uint8_t u8MOSI, uint8_t u8SCK, uint32_t u32Speed);
 void bbepWakeUp(BBEPDISP *pBBEP);
 void bbepSendCMDSequence(BBEPDISP *pBBEP, const uint8_t *pSeq);
@@ -513,6 +514,7 @@ void initDataBuses(){
 }
 
 void initio(){
+    writeSerial("[initio] >> LEDs", true); flushLog();
     if(globalConfig.led_count > 0){
         for (uint8_t i = 0; i < globalConfig.led_count; i++) {
             struct LedConfig* led = &globalConfig.leds[i];
@@ -552,7 +554,9 @@ void initio(){
             }
         }
     }
+    writeSerial("[initio] >> initPassiveBuzzers", true); flushLog();
     initPassiveBuzzers();
+    writeSerial("[initio] >> pwr_pin", true); flushLog();
     if(globalConfig.system_config.pwr_pin != 0xFF){
     pinMode(globalConfig.system_config.pwr_pin, OUTPUT);
     digitalWrite(globalConfig.system_config.pwr_pin, LOW);
@@ -560,8 +564,11 @@ void initio(){
     else{
         writeSerial("Power pin not set", true);
     }
+    writeSerial("[initio] >> initDataBuses", true); flushLog();
     initDataBuses();
+    writeSerial("[initio] >> initSensors", true); flushLog();
     initSensors();
+    writeSerial("[initio] << done", true); flushLog();
 }
 
 void scanI2CDevices(){

--- a/src/display_service.h
+++ b/src/display_service.h
@@ -34,6 +34,11 @@ void handleDirectWriteData(uint8_t* data, uint16_t len);
 void handleDirectWriteCompressedData(uint8_t* data, uint16_t len);
 void cleanupDirectWriteState(bool refreshDisplay);
 void handleDirectWriteEnd(uint8_t* data, uint16_t len);
+// True while an image push is mid-stream and the per-frame command/ack logging
+// should be suppressed (chunk 1 still logs in full; the meter covers the rest).
+bool imageWriteLogQuietCmd(void);
+bool imageWriteLogQuietAck(void);
+bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len);
 extern volatile bool epdRefreshInProgress;
 void handlePartialWriteStart(uint8_t* data, uint16_t len);
 void checkPartialWriteTimeout(void);

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -10,6 +10,10 @@
 #include <string.h>
 #include "ble_init.h"
 
+// Defined in display_service.cpp. True for a mid-stream image-write data frame
+// (0x0071) whose per-frame receive/queue logging should be suppressed.
+bool imageWriteLogQuietFrame(const uint8_t* data, uint16_t len);
+
 #ifndef COMMAND_QUEUE_SIZE
 #define COMMAND_QUEUE_SIZE 5
 #endif
@@ -67,25 +71,30 @@ public:
     }
 #endif
     void onWrite(BLECharacteristic* pCharacteristic) {
-        writeSerial("=== BLE WRITE RECEIVED (ESP32) ===");
         String value = pCharacteristic->getValue();
-        writeSerial("Received data length: " + String(value.length()) + " bytes");
+        const bool quiet = imageWriteLogQuietFrame((const uint8_t*)value.c_str(), value.length());
+        if (!quiet) {
+            writeSerial("=== BLE WRITE RECEIVED (ESP32) ===");
+            writeSerial("Received data length: " + String(value.length()) + " bytes");
+        }
         if (value.length() > 0 && value.length() <= MAX_COMMAND_SIZE) {
             uint8_t* data = (uint8_t*)value.c_str();
             uint16_t len = value.length();
-            String hexDump = "Data: ";
-            for (int i = 0; i < len && i < 16; i++) {
-                if (data[i] < 16) hexDump += "0";
-                hexDump += String(data[i], HEX) + " ";
+            if (!quiet) {
+                String hexDump = "Data: ";
+                for (int i = 0; i < len && i < 16; i++) {
+                    if (data[i] < 16) hexDump += "0";
+                    hexDump += String(data[i], HEX) + " ";
+                }
+                writeSerial(hexDump);
             }
-            writeSerial(hexDump);
             uint8_t nextHead = (commandQueueHead + 1) % COMMAND_QUEUE_SIZE;
             if (nextHead != commandQueueTail) {
                 memcpy(commandQueue[commandQueueHead].data, data, len);
                 commandQueue[commandQueueHead].len = len;
                 commandQueue[commandQueueHead].pending = true;
                 commandQueueHead = nextHead;
-                writeSerial("ESP32: Command queued for processing");
+                if (!quiet) writeSerial("ESP32: Command queued for processing");
             } else {
                 writeSerial("ERROR: Command queue full, dropping command");
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,22 +131,24 @@ void loop() {
         return;
     }
     if (commandQueueTail != commandQueueHead) {
-        writeSerial("ESP32: Processing queued command (" + String(commandQueue[commandQueueTail].len) + " bytes)");
+        const bool quietCmd = imageWriteLogQuietFrame(commandQueue[commandQueueTail].data, commandQueue[commandQueueTail].len);
+        if (!quietCmd) writeSerial("ESP32: Processing queued command (" + String(commandQueue[commandQueueTail].len) + " bytes)");
         imageDataWritten(NULL, NULL, commandQueue[commandQueueTail].data, commandQueue[commandQueueTail].len);
         commandQueue[commandQueueTail].pending = false;
         commandQueueTail = (commandQueueTail + 1) % COMMAND_QUEUE_SIZE;
-        writeSerial("Command processed");
+        if (!quietCmd) writeSerial("Command processed");
     }
     if (responseQueueTail != responseQueueHead) {
         if (esp32_ble_notify_enabled()) {
             uint8_t bleDrain = 0;
             while (responseQueueTail != responseQueueHead && bleDrain < 16) {
-                writeSerial("ESP32: Sending queued response (" + String(responseQueue[responseQueueTail].len) + " bytes)");
+                const bool quietAck = imageWriteLogQuietFrame(responseQueue[responseQueueTail].data, responseQueue[responseQueueTail].len);
+                if (!quietAck) writeSerial("ESP32: Sending queued response (" + String(responseQueue[responseQueueTail].len) + " bytes)");
                 pTxCharacteristic->setValue(responseQueue[responseQueueTail].data, responseQueue[responseQueueTail].len);
                 pTxCharacteristic->notify();
                 responseQueue[responseQueueTail].pending = false;
                 responseQueueTail = (responseQueueTail + 1) % RESPONSE_QUEUE_SIZE;
-                writeSerial("Response sent successfully");
+                if (!quietAck) writeSerial("Response sent successfully");
                 bleDrain++;
             }
         } else if (pServer && pServer->getConnectedCount() > 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,27 @@
 static HardwareSerial LogSerialPort(1);
 #endif
 
+#ifdef TARGET_ESP32
+// Distinguishes a hidden mid-cycle reset (PANIC/WDT/BROWNOUT/SW) from a real
+// power-on or deep-sleep wake; any reset here clears the wake cause, so the
+// next boot takes the NORMAL BOOT branch and redraws the boot screen.
+static const char* resetReasonName(esp_reset_reason_t reason) {
+    switch (reason) {
+        case ESP_RST_POWERON:   return "POWERON";
+        case ESP_RST_EXT:       return "EXT";
+        case ESP_RST_SW:        return "SW";
+        case ESP_RST_PANIC:     return "PANIC";
+        case ESP_RST_INT_WDT:   return "INT_WDT";
+        case ESP_RST_TASK_WDT:  return "TASK_WDT";
+        case ESP_RST_WDT:       return "WDT";
+        case ESP_RST_DEEPSLEEP: return "DEEPSLEEP";
+        case ESP_RST_BROWNOUT:  return "BROWNOUT";
+        case ESP_RST_SDIO:      return "SDIO";
+        default:                return "UNKNOWN";
+    }
+}
+#endif
+
 void setup() {
     #if defined(TARGET_ESP32) && defined(OPENDISPLAY_LOG_UART)
     LogSerialPort.begin(115200, SERIAL_8N1, OPENDISPLAY_LOG_UART_RX, OPENDISPLAY_LOG_UART_TX);
@@ -40,6 +61,8 @@ void setup() {
         writeSerial("Git SHA: (not set)");
     }
     #ifdef TARGET_ESP32
+    esp_reset_reason_t reset_reason = esp_reset_reason();
+    writeSerial("Reset reason: " + String(resetReasonName(reset_reason)) + " (" + String((int)reset_reason) + ")");
     esp_sleep_wakeup_cause_t wakeup_reason = esp_sleep_get_wakeup_cause();
     bool is_deep_sleep_wake = (wakeup_reason != ESP_SLEEP_WAKEUP_UNDEFINED);
     if (is_deep_sleep_wake) {
@@ -53,6 +76,9 @@ void setup() {
     } else {
         woke_from_deep_sleep = false;
         writeSerial("=== NORMAL BOOT ===");
+        // RTC memory survives soft resets (panic/WDT/esp_restart) but not power
+        // loss: a non-zero count on a NORMAL BOOT means a hidden mid-cycle reset.
+        writeSerial("Deep sleep count (RTC): " + String(deep_sleep_count));
     }
     #endif
     writeSerial("Starting setup...");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,9 +270,13 @@ void idleDelay(uint32_t delayMs) {
 #ifdef TARGET_ESP32
 void minimalSetup() {
     writeSerial("=== Minimal Setup (Deep Sleep Wake) ===");
+    writeSerial("[wake] >> full_config_init"); flushLog();
     full_config_init();
+    writeSerial("[wake] << full_config_init >> initio"); flushLog();
     initio();
+    writeSerial("[wake] << initio >> ble_init_esp32"); flushLog();
     ble_init_esp32(true); // Update manufacturer data
+    writeSerial("[wake] << ble_init_esp32"); flushLog();
     writeSerial("=== BLE advertising started (minimal mode) ===");
     writeSerial("Advertising for 10 seconds, waiting for connection...");
     advertising_timeout_active = true;
@@ -461,6 +465,21 @@ void writeSerial(String message, bool newLine){
     #elif !defined(DISABLE_USB_SERIAL)
     if (newLine == true) Serial.println(message);
     else Serial.print(message);
+    #endif
+}
+
+// Blocks until the log UART has physically drained. The IDF panic handler only
+// flushes the console UART, so without this the last lines before a crash are
+// lost on the OPENDISPLAY_LOG_UART port — call after a marker to guarantee it
+// reaches the wire before a suspect call can fault.
+void flushLog(){
+    #if defined(TARGET_ESP32) && defined(OPENDISPLAY_LOG_UART)
+    LogSerialPort.flush();
+    #elif !defined(DISABLE_USB_SERIAL)
+    Serial.flush();
+    #endif
+    #ifdef TARGET_ESP32
+    delay(5);
     #endif
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -182,6 +182,7 @@ void powerDownExternalFlashFromConfig(void);
 void xiaoinit();
 void ws_pp_init();
 void writeSerial(String message, bool newLine = true);
+void flushLog();
 void connect_callback(uint16_t conn_handle);
 void disconnect_callback(uint16_t conn_handle, uint8_t reason);
 #ifdef TARGET_ESP32


### PR DESCRIPTION
## Summary

This branch bundles a SEEED-panel deep-sleep wake fix with its supporting diagnostics and a rework of image-write logging. Five commits:

- **fix: full TCON re-init on first SEEED render after deep-sleep wake** — On the ED103TC2/IT8951 SEEED_GFX path, deep-sleep wake is a full reboot that power-cycles the panel/TCON rail, but the post-wake direct-write seam only called `EPaper::wake()` (a no-op after reboot that skips `hostTconInit()` — VCOM / panel dimensions / I80CPCR packed-pixel mode). A plain-RAM (not `RTC_DATA_ATTR`) init flag now forces a full `begin()` on the first render each boot, keeping the cheap `wake()` for later same-session writes. The non-SEEED bb_epaper path re-inits unconditionally and is unaffected.

- **feat: quiet image-write logging with progress meter and throughput** — An image push logged 6-8 lines per `0x71` data frame (~1 MB of UART text for a 1.3 MB image); at 115200 baud `writeSerial` blocks once the TX buffer fills, throttling the transfer itself. Replaced with a compact stream log: the first frame in full, a 5%-step percentage meter, and a completion summary with the final frame, chunk count, elapsed time, and KB/s. New helpers in `display_service.cpp` drive the meter; predicates gate the per-frame lines in `communication.cpp`, `main.cpp`'s queue drain, and the ESP32 BLE receive callback while keeping chunk 1, errors, and NACKs visible. Covers direct- and partial-write paths.

- **Diagnostics (supporting the wake fix):** boot-time reset-reason logging, flushed bisection markers on the wake path, and a findings doc recording the confirmed PANIC diagnosis. These are diagnostic scaffolding — flagging in case they should be dropped or squashed before merge.

## Testing

Builds clean on `esp32-s3-N16R8-extuart` (SEEED + UART log), `esp32-s3-N32R8-extuart`, `nrf52840custom`, and `esp32-c3-N16`. On-device UART capture confirms the meter and quiet mid-stream behavior; the TCON re-init still needs the full flash-and-wake-cycle validation on the reTerminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)