### PR TITLE
fix(nrf): guard Wire.begin() behind I2C bus config check

### DIFF
--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -440,26 +440,17 @@ void initOrRestoreWireForOpenDisplay(void) {
         }
     }
 #else
-    if (globalConfig.data_bus_count > 0) {
+    if (!openDisplayI2cBusConfigured()) {
+        return;
+    }
+    if (i2cDataBusValid(0)) {
         const struct DataBus& bus = globalConfig.data_buses[0];
-        if (bus.bus_type == 0x01 && bus.pin_1 != 0xFF && bus.pin_2 != 0xFF) {
-            uint32_t hz = bus.bus_speed_hz ? bus.bus_speed_hz : 100000u;
-            pinMode(bus.pin_1, INPUT);
-            pinMode(bus.pin_2, INPUT);
-            if (bus.pullups & 0x01) {
-                pinMode(bus.pin_1, INPUT_PULLUP);
-            }
-            if (bus.pullups & 0x02) {
-                pinMode(bus.pin_2, INPUT_PULLUP);
-            }
-        }
+        pinMode(bus.pin_1, (bus.pullups & 0x01) ? INPUT_PULLUP : INPUT);
+        pinMode(bus.pin_2, (bus.pullups & 0x02) ? INPUT_PULLUP : INPUT);
     }
     Wire.begin();
-    if (globalConfig.data_bus_count > 0) {
-        const struct DataBus& bus = globalConfig.data_buses[0];
-        if (bus.bus_speed_hz > 0) {
-            Wire.setClock(bus.bus_speed_hz);
-        }
+    if (i2cDataBusValid(0) && globalConfig.data_buses[0].bus_speed_hz > 0) {
+        Wire.setClock(globalConfig.data_buses[0].bus_speed_hz);
     }
 #endif
 }


### PR DESCRIPTION
- Wire.begin() on nRF claimed default SCL/SDA pins (D5/D4) via TWI even when no I2C buses were configured, holding SCL HIGH via the internal pull-up and masking EPD BUSY signals on shared pins
- Guard with openDisplayI2cBusConfigured() so TWI is never started unless a valid I2C bus exists in the factory config
- Simplify pin-setup and setClock using i2cDataBusValid(0), removing redundant bus_type/pin checks and a dead hz variable