### PR TITLE
fix(ble): pass deleteCallbacks=false when setting characteristic callbacks

### DIFF
--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -283,7 +283,7 @@ void ble_init_esp32(bool update_manufacturer_data) {
     }
     writeSerial("Characteristic created with properties: READ, NOTIFY, WRITE, WRITE_NR");
     // NimBLE auto-adds the 0x2902 CCCD for NOTIFY characteristics; no BLE2902 needed.
-    pTxCharacteristic->setCallbacks(&staticCharCallbacks);
+    pTxCharacteristic->setCallbacks(&staticCharCallbacks, false);
     pRxCharacteristic = pTxCharacteristic;
     // NimBLE starts services automatically when the server starts advertising; no
     // explicit pService->start() (deprecated no-op in NimBLE 2.x).


### PR DESCRIPTION
staticCharCallbacks is a static global object, not heap-allocated. Without `deleteCallbacks=false`, NimBLE would attempt to delete it on `BLEDevice::deinit(true)`, which runs on every deep-sleep entry, causing undefined behavior. Mirrors the existing fix already applied to `pServer->setCallbacks()` ~20 lines above.