### PR TITLE
Add new od_log() system

### DIFF
--- a/src/ble_init.cpp
+++ b/src/ble_init.cpp
@@ -2,6 +2,7 @@
 #include "structs.h"
 #include "encryption.h"
 #include "display_service.h"
+#include "od_log.h"
 
 #ifdef TARGET_NRF
 #include <bluefruit.h>
@@ -16,13 +17,11 @@ void connect_callback(uint16_t conn_handle);
 void disconnect_callback(uint16_t conn_handle, uint8_t reason);
 void imageDataWritten(uint16_t conn_hdl, BLECharacteristic* chr, uint8_t* data, uint16_t len);
 String getChipIdHex();
-void writeSerial(String message, bool newLine = true);
 #endif
 
 #ifdef TARGET_ESP32
 // NimBLE-Arduino + BLE* aliases arrive via ble_init.h (included above).
 String getChipIdHex();
-void writeSerial(String message, bool newLine = true);
 #include "esp32_ble_callbacks.h"
 
 extern struct GlobalConfig globalConfig;
@@ -84,7 +83,7 @@ void ble_nrf_advertising_tick(void) {
 void ble_nrf_log_link_params(uint16_t conn_handle, const char* phase) {
     BLEConnection* conn = Bluefruit.Connection(conn_handle);
     if (conn == nullptr) {
-        writeSerial(String("[LINK ") + phase + "] no connection (handle " + String(conn_handle) + ")");
+        od_log_debug("[LINK %s] no connection (handle %u)", phase, conn_handle);
         return;
     }
     uint8_t  phy = conn->getPHY();
@@ -93,10 +92,8 @@ void ble_nrf_log_link_params(uint16_t conn_handle, const char* phase) {
     uint16_t ci  = conn->getConnectionInterval(); // units of 1.25 ms
     const char* phyStr = (phy == BLE_GAP_PHY_2MBPS) ? "2M" :
                          (phy == BLE_GAP_PHY_1MBPS) ? "1M" : "?";
-    writeSerial(String("[LINK ") + phase + "] PHY=" + phyStr +
-                "  ATT_MTU=" + String(mtu) +
-                "  DLE=" + String(dle) + " octets" +
-                "  connInterval=" + String(ci * 1.25f, 2) + " ms");
+    od_log_debug("[LINK %s] PHY=%s  ATT_MTU=%u  DLE=%u octets  connInterval=%.2f ms",
+                 phase, phyStr, mtu, dle, ci * 1.25f);
 }
 
 // One-shot timer (armed only in connect_callback — no per-loop polling). Fires
@@ -129,11 +126,11 @@ void ble_nrf_request_fast_link(uint16_t conn_handle) {
     dl.max_rx_time_us = BLE_GAP_DATA_LENGTH_AUTO;
     ble_gap_data_length_limitation_t limit = { 0, 0, 0 };
     if (!conn->requestDataLengthUpdate(&dl, &limit)) {
-        writeSerial("DLE 251 request rejected (tx_lim=" + String(limit.tx_payload_limited_octets) +
-                    " rx_lim=" + String(limit.rx_payload_limited_octets) +
-                    " time_lim_us=" + String(limit.tx_rx_time_limited_us) + ")");
+        od_log_warn("DLE 251 request rejected (tx_lim=%u rx_lim=%u time_lim_us=%u)",
+                    limit.tx_payload_limited_octets, limit.rx_payload_limited_octets,
+                    limit.tx_rx_time_limited_us);
     }
-    writeSerial("Requested fast link: 2M PHY + 251-octet DLE");
+    od_log_debug("Requested fast link: 2M PHY + 251-octet DLE");
 }
 
 void ble_nrf_arm_link_diag(uint16_t conn_handle) {
@@ -153,14 +150,14 @@ void ble_nrf_stack_init() {
     Bluefruit.autoConnLed(false);
     Bluefruit.setTxPower(globalConfig.power_option.tx_power);
     Bluefruit.begin(1, 0);
-    writeSerial("BLE initialized successfully");
-    writeSerial("Setting up BLE service 0x2446...");
+    od_log_info("BLE initialized successfully");
+    od_log_info("Setting up BLE service 0x2446...");
     imageService.begin();
-    writeSerial("BLE service started");
+    od_log_info("BLE service started");
     imageCharacteristic.setWriteCallback(imageDataWritten);
-    writeSerial("BLE write callback set");
+    od_log_info("BLE write callback set");
     imageCharacteristic.begin();
-    writeSerial("BLE characteristic started");
+    od_log_info("BLE characteristic started");
     // Register the DFU service LAST so its presence/absence (it is only added when
     // encryption is disabled) never shifts the handles of imageCharacteristic and its
     // CCCD. GATT handles are assigned in begin() order; keeping the app characteristic
@@ -169,24 +166,24 @@ void ble_nrf_stack_init() {
     // with ATT "Invalid handle". Must stay after Bluefruit.begin() (SoftDevice up first).
     if (!isEncryptionEnabled()) {
         bledfu.begin();
-        writeSerial("BLE DFU initialized successfully (encryption disabled)");
+        od_log_info("BLE DFU initialized successfully (encryption disabled)");
     } else {
-        writeSerial("BLE DFU service NOT initialized (encryption enabled - use CMD_ENTER_DFU)");
+        od_log_info("BLE DFU service NOT initialized (encryption enabled - use CMD_ENTER_DFU)");
     }
     Bluefruit.Periph.setConnectCallback(connect_callback);
     Bluefruit.Periph.setDisconnectCallback(disconnect_callback);
-    writeSerial("BLE callbacks registered");
+    od_log_info("BLE callbacks registered");
     String deviceName = "OD" + getChipIdHex();
     Bluefruit.setName(deviceName.c_str());
-    writeSerial("Device name set to: " + deviceName);
-    writeSerial("Configuring power management...");
+    od_log_info("Device name set to: %s", deviceName.c_str());
+    od_log_info("Configuring power management...");
     sd_power_mode_set(NRF_POWER_MODE_LOWPWR);
     sd_power_dcdc_mode_set(NRF_POWER_DCDC_ENABLE);
-    writeSerial("Power management configured");
+    od_log_info("Power management configured");
 }
 
 void ble_nrf_advertising_start() {
-    writeSerial("Configuring BLE advertising...");
+    od_log_info("Configuring BLE advertising...");
     Bluefruit.Advertising.clearData();
     Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
     Bluefruit.Advertising.addName();
@@ -194,7 +191,7 @@ void ble_nrf_advertising_start() {
     Bluefruit.Advertising.restartOnDisconnect(true);
     ble_nrf_apply_adv_interval();
     Bluefruit.Advertising.setFastTimeout(10);
-    writeSerial("Starting BLE advertising...");
+    od_log_info("Starting BLE advertising...");
     Bluefruit.Advertising.start(0);
 }
 #endif
@@ -244,33 +241,33 @@ void esp32_restart_ble_advertising(void) {
     delay(100);
     BLEDevice::startAdvertising();
     updatemsdata();
-    writeSerial("BLE advertising restarted");
+    od_log_info("BLE advertising restarted");
 }
 
 void ble_init_esp32(bool update_manufacturer_data) {
     esp32_ble_clear_handles();
-    writeSerial("=== Initializing ESP32 BLE ===");
+    od_log_info("=== Initializing ESP32 BLE ===");
     String deviceName = "OD" + getChipIdHex();
-    writeSerial("Device name will be: " + deviceName);
+    od_log_info("Device name will be: %s", deviceName.c_str());
     BLEDevice::init(deviceName.c_str());
-    writeSerial("Setting BLE MTU to 512...");
+    od_log_info("Setting BLE MTU to 512...");
     BLEDevice::setMTU(512);
     pServer = BLEDevice::createServer();
     if (pServer == nullptr) {
-        writeSerial("ERROR: Failed to create BLE server");
+        od_log_error("ERROR: Failed to create BLE server");
         return;
     }
     // deleteCallbacks=false: staticServerCallbacks is a static object; NimBLE must
     // not delete it on deinit()/replacement.
     pServer->setCallbacks(&staticServerCallbacks, false);
-    writeSerial("Server callbacks configured");
+    od_log_info("Server callbacks configured");
     BLEUUID serviceUUID("00002446-0000-1000-8000-00805F9B34FB");
     pService = pServer->createService(serviceUUID);
     if (pService == nullptr) {
-        writeSerial("ERROR: Failed to create BLE service");
+        od_log_error("ERROR: Failed to create BLE service");
         return;
     }
-    writeSerial("BLE service 0x2446 created successfully");
+    od_log_info("BLE service 0x2446 created successfully");
     BLEUUID charUUID("00002446-0000-1000-8000-00805F9B34FB");
     pTxCharacteristic = pService->createCharacteristic(
         charUUID,
@@ -280,10 +277,10 @@ void ble_init_esp32(bool update_manufacturer_data) {
         NIMBLE_PROPERTY::WRITE_NR
     );
     if (pTxCharacteristic == nullptr) {
-        writeSerial("ERROR: Failed to create BLE characteristic");
+        od_log_error("ERROR: Failed to create BLE characteristic");
         return;
     }
-    writeSerial("Characteristic created with properties: READ, NOTIFY, WRITE, WRITE_NR");
+    od_log_info("Characteristic created with properties: READ, NOTIFY, WRITE, WRITE_NR");
     // NimBLE auto-adds the 0x2902 CCCD for NOTIFY characteristics; no BLE2902 needed.
     pTxCharacteristic->setCallbacks(&staticCharCallbacks);
     pRxCharacteristic = pTxCharacteristic;
@@ -291,14 +288,14 @@ void ble_init_esp32(bool update_manufacturer_data) {
     // explicit pService->start() (deprecated no-op in NimBLE 2.x).
     BLEAdvertising* pAdvertising = BLEDevice::getAdvertising();
     if (pAdvertising == nullptr) {
-        writeSerial("ERROR: Failed to get advertising object");
+        od_log_error("ERROR: Failed to get advertising object");
         return;
     }
     pAdvertising->addServiceUUID(serviceUUID);
-    writeSerial("Service UUID added to advertising");
+    od_log_info("Service UUID added to advertising");
     advertisementData->setName(deviceName.c_str());
     advertisementData->setFlags(0x06);
-    writeSerial("Device name added to advertising");
+    od_log_info("Device name added to advertising");
     if (update_manufacturer_data) {
         updatemsdata();
     }
@@ -309,8 +306,8 @@ void ble_init_esp32(bool update_manufacturer_data) {
     // response is off by default in NimBLE 2.x, so no enableScanResponse() needed.
     pAdvertising->setAdvertisementData(*advertisementData);
     pServer->getAdvertising()->start();
-    writeSerial("=== BLE advertising started successfully ===");
-    writeSerial("Device ready: " + deviceName);
-    writeSerial("Waiting for BLE connections...");
+    od_log_info("=== BLE advertising started successfully ===");
+    od_log_info("Device ready: %s", deviceName.c_str());
+    od_log_info("Waiting for BLE connections...");
 }
 #endif

--- a/src/boot_screen.cpp
+++ b/src/boot_screen.cpp
@@ -7,6 +7,7 @@
 #include <bb_epaper.h>
 #include "qr/qrcode.h"
 #include "display_service.h"
+#include "od_log.h"
 #if __has_include("logo_bitmap.h")
 #include "logo_bitmap.h"
 #define BOOT_HAS_LOGO
@@ -25,7 +26,6 @@ uint8_t getFirmwareMajor();
 uint8_t getFirmwareMinor();
 int getBitsPerPixel();
 int getplane();
-void writeSerial(String message, bool newLine);
 void bbepSetAddrWindow(BBEPDISP *pBBEP, int x, int y, int cx, int cy);
 void bbepStartWrite(BBEPDISP *pBBEP, int iPlane);
 void bbepWriteData(BBEPDISP *pBBEP, uint8_t *pData, int iLen);
@@ -924,11 +924,11 @@ bool writeBootScreenWithQr() {
         if (e1004Stream) {
             if (halfPass == 0) {
                 if (!e1004_begin_plane()) {
-                    writeSerial("Boot screen: E1004 dual-CS plane open failed", true);
+                    od_log_error("Boot screen: E1004 dual-CS plane open failed");
                     return false;
                 }
             } else if (!e1004_advance_to_cs2()) {
-                writeSerial("Boot screen: E1004 CS2 advance failed", true);
+                od_log_error("Boot screen: E1004 CS2 advance failed");
                 e1004_end_plane();
                 return false;
             }
@@ -1058,6 +1058,6 @@ bool writeBootScreenWithQr() {
             for (uint16_t y = 0; y < h; y++) bbepWriteData(&bbep, row, pitch);
         }
     }
-    writeSerial("Boot screen with QR rendered", true);
+    od_log_info("Boot screen with QR rendered");
     return true;
 }

--- a/src/communication.cpp
+++ b/src/communication.cpp
@@ -5,6 +5,7 @@
 #include "device_control.h"
 #include "buzzer_control.h"
 #include "display_service.h"
+#include "od_log.h"
 
 #include <Arduino.h>
 #include <string.h>
@@ -20,17 +21,16 @@ extern BLEServer* pServer;
 #include <bluefruit.h>
 #endif
 
-void writeSerial(String message, bool newLine = true);
 bool isAuthenticated();
 extern struct GlobalConfig globalConfig;
 
 static void reloadConfigAfterSave(void) {
     if (!loadGlobalConfig()) {
-        writeSerial("WARNING: Config was saved but reload from storage failed (see errors above). "
+        od_log_warn("WARNING: Config was saved but reload from storage failed (see errors above). "
                     "Reboot may be required.");
         return;
     }
-    writeSerial("Config reloaded from storage after save");
+    od_log_info("Config reloaded from storage after save");
     // Live-disable takes effect now: with keep-alive off, drop a still-warm panel
     // here instead of waiting out the stale (<=30 s) deadline armed by the last push.
     if (globalConfig.power_option.screen_timeout_seconds == 0 && epdSessionIsWarm()) {
@@ -84,14 +84,14 @@ static void send_wifi_lan_frame(const uint8_t* payload, uint16_t len) {
     }
     uint8_t hdr[2] = { (uint8_t)(len & 0xFF), (uint8_t)((len >> 8) & 0xFF) };
     if (wifiClient.write(hdr, 2) != 2 || wifiClient.write(payload, len) != len) {
-        writeSerial("ERROR: LAN response write incomplete", true);
+        od_log_error("ERROR: LAN response write incomplete");
     }
 }
 
 /** Mirror responses to BLE only when a central is connected; LAN already got send_wifi_lan_frame. */
 static void esp32_queue_ble_notify_copy(const uint8_t* response, uint16_t len, bool quiet = false) {
     if (len > MAX_RESPONSE_SIZE_LOCAL) {
-        writeSerial("ERROR: Response too large for queue (" + String(len) + " > " + String(MAX_RESPONSE_SIZE_LOCAL) + ")", true);
+        od_log_error("ERROR: Response too large for queue (%u > %u)", len, MAX_RESPONSE_SIZE_LOCAL);
         return;
     }
     if (pServer == nullptr || pServer->getConnectedCount() == 0) {
@@ -99,14 +99,17 @@ static void esp32_queue_ble_notify_copy(const uint8_t* response, uint16_t len, b
     }
     uint8_t nextHead = (responseQueueHead + 1) % RESPONSE_QUEUE_SIZE_LOCAL;
     if (nextHead == responseQueueTail) {
-        writeSerial("ERROR: Response queue full, dropping response", true);
+        od_log_error("ERROR: Response queue full, dropping response");
         return;
     }
     memcpy(responseQueue[responseQueueHead].data, response, len);
     responseQueue[responseQueueHead].len = len;
     responseQueue[responseQueueHead].pending = true;
     responseQueueHead = nextHead;
-    if (!quiet) writeSerial("ESP32: Response queued (queue size: " + String((responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE_LOCAL) % RESPONSE_QUEUE_SIZE_LOCAL) + ")", true);
+    if (!quiet) {
+        uint8_t queueSize = (responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE_LOCAL) % RESPONSE_QUEUE_SIZE_LOCAL;
+        od_log_debug("ESP32: Response queued (queue size: %u)", queueSize);
+    }
 }
 #endif
 
@@ -128,38 +131,48 @@ static constexpr uint8_t FIRMWARE_SHA_HEX_BYTES = 40;
 static const char kFirmwareShaPlaceholder[FIRMWARE_SHA_HEX_BYTES + 1] =
     "0000000000000000000000000000000000000000";
 
-void sendResponseUnencrypted(uint8_t* response, uint16_t len) {
-    writeSerial("Sending unencrypted response (error/status):", true);
-    writeSerial("  Length: " + String(len) + " bytes", true);
-    writeSerial("  Command: 0x" + String(response[0], HEX) + String(response[1], HEX), true);
-    String hexDump = "  Full command: ";
-    for (int i = 0; i < len && i < 32; i++) {
-        if (i > 0) hexDump += " ";
-        if (response[i] < 16) hexDump += "0";
-        hexDump += String(response[i], HEX);
+// Builds "<label><space-separated %02X bytes, up to 32><' ...' if truncated>" into buf.
+static void buildHexDump(char* buf, size_t bufSize, const char* label, const uint8_t* data, uint16_t len) {
+    int pos = snprintf(buf, bufSize, "%s", label);
+    if (pos < 0) {
+        pos = 0;
+        buf[0] = '\0';
     }
-    if (len > 32) hexDump += " ...";
-    writeSerial(hexDump, true);
+    int dumpLen = (len < 32) ? len : 32;
+    for (int i = 0; i < dumpLen && pos < (int)bufSize; i++) {
+        int n = snprintf(buf + pos, bufSize - pos, i > 0 ? " %02X" : "%02X", data[i]);
+        if (n < 0) {
+            break;
+        }
+        pos += n;
+    }
+    if (len > 32 && pos >= 0 && pos < (int)bufSize) {
+        snprintf(buf + pos, bufSize - pos, " ...");
+    }
+}
+
+void sendResponseUnencrypted(uint8_t* response, uint16_t len) {
+    od_log_debug("Sending unencrypted response (error/status):");
+    od_log_debug("  Length: %u bytes", len);
+    od_log_debug("  Command: 0x%02X%02X", response[0], response[1]);
+    char hexDump[160];
+    buildHexDump(hexDump, sizeof(hexDump), "  Full command: ", response, len);
+    od_log_debug("%s", hexDump);
 #ifdef TARGET_ESP32
     send_wifi_lan_frame(response, len);
     esp32_queue_ble_notify_copy(response, len);
 #endif
 #ifdef TARGET_NRF
     if (Bluefruit.connected() && imageCharacteristic.notifyEnabled()) {
-        String nrfHexDump = "NRF: Sending unencrypted response: ";
-        for (int i = 0; i < len && i < 32; i++) {
-            if (i > 0) nrfHexDump += " ";
-            if (response[i] < 16) nrfHexDump += "0";
-            nrfHexDump += String(response[i], HEX);
-        }
-        if (len > 32) nrfHexDump += "...";
-        writeSerial(nrfHexDump, true);
-        writeSerial("NRF: BLE notification sent (" + String(len) + " bytes)", true);
+        char nrfHexDump[160] = {0};
+        buildHexDump(nrfHexDump, sizeof(nrfHexDump), "NRF: Sending unencrypted response: ", response, len);
+        od_log_debug("%s", nrfHexDump);
+        od_log_debug("NRF: BLE notification sent (%u bytes)", len);
         imageCharacteristic.notify(response, len);
     } else {
-        writeSerial("ERROR: Cannot send BLE response - not connected or notifications not enabled", true);
-        writeSerial("  Connected: " + String(Bluefruit.connected() ? "yes" : "no"), true);
-        writeSerial("  Notify enabled: " + String(imageCharacteristic.notifyEnabled() ? "yes" : "no"), true);
+        od_log_error("ERROR: Cannot send BLE response - not connected or notifications not enabled");
+        od_log_error("  Connected: %s", Bluefruit.connected() ? "yes" : "no");
+        od_log_error("  Notify enabled: %s", imageCharacteristic.notifyEnabled() ? "yes" : "no");
     }
 #endif
 }
@@ -193,14 +206,14 @@ void sendResponse(uint8_t* response, uint16_t len) {
             uint16_t encrypted_len = 0;
             if (encryptResponse(response, len, encrypted_response, &encrypted_len, nonce, auth_tag)) {
                 if (!quietAck) {
-                    writeSerial("Sending encrypted response:", true);
-                    writeSerial("  Original length: " + String(len) + " bytes", true);
-                    writeSerial("  Encrypted length: " + String(encrypted_len) + " bytes", true);
+                    od_log_debug("Sending encrypted response:");
+                    od_log_debug("  Original length: %u bytes", len);
+                    od_log_debug("  Encrypted length: %u bytes", encrypted_len);
                 }
                 response = encrypted_response;
                 len = encrypted_len;
             } else {
-                writeSerial("WARNING: Failed to encrypt response, sending unencrypted error response", true);
+                od_log_warn("WARNING: Failed to encrypt response, sending unencrypted error response");
                 errorResponse[0] = RESP_NACK;
                 errorResponse[1] = (uint8_t)(command & 0xFF);
                 errorResponse[2] = 0x00;
@@ -208,7 +221,7 @@ void sendResponse(uint8_t* response, uint16_t len) {
                 len = sizeof(errorResponse);
             }
         } else if (!quietAck) {
-            writeSerial("Sending unencrypted response (authentication/firmware version/error)", true);
+            od_log_debug("Sending unencrypted response (authentication/firmware version/error)");
         }
     }
 
@@ -216,16 +229,24 @@ void sendResponse(uint8_t* response, uint16_t len) {
         // One-line TX log: opcode, length, and up to 32 payload bytes (the opcode
         // is also the first two bytes of the dump). Replaces the old 4-line block.
         uint16_t cmd = (response[0] << 8) | response[1];
-        char head[32];
-        snprintf(head, sizeof(head), "BLE: TX 0x%04X (%u B):", cmd, (unsigned)len);
-        String line = head;
-        for (int i = 0; i < len && i < 32; i++) {
-            char b[4];
-            snprintf(b, sizeof(b), " %02X", response[i]);
-            line += b;
+        char line[160];
+        int pos = snprintf(line, sizeof(line), "BLE: TX 0x%04X (%u B):", cmd, (unsigned)len);
+        if (pos < 0) {
+            pos = 0;
+            line[0] = '\0';
         }
-        if (len > 32) line += " ...";
-        writeSerial(line, true);
+        int dumpLen = (len < 32) ? len : 32;
+        for (int i = 0; i < dumpLen && pos < (int)sizeof(line); i++) {
+            int n = snprintf(line + pos, sizeof(line) - pos, " %02X", response[i]);
+            if (n < 0) {
+                break;
+            }
+            pos += n;
+        }
+        if (len > 32 && pos >= 0 && pos < (int)sizeof(line)) {
+            snprintf(line + pos, sizeof(line) - pos, " ...");
+        }
+        od_log_debug("%s", line);
     }
 #ifdef TARGET_ESP32
     send_wifi_lan_frame(response, len);
@@ -234,15 +255,10 @@ void sendResponse(uint8_t* response, uint16_t len) {
 #ifdef TARGET_NRF
     if (Bluefruit.connected() && imageCharacteristic.notifyEnabled()) {
         if (!quietAck) {
-            String nrfHexDump = "NRF: Sending response: ";
-            for (int i = 0; i < len && i < 32; i++) {
-                if (i > 0) nrfHexDump += " ";
-                if (response[i] < 16) nrfHexDump += "0";
-                nrfHexDump += String(response[i], HEX);
-            }
-            if (len > 32) nrfHexDump += "...";
-            writeSerial(nrfHexDump, true);
-            writeSerial("NRF: BLE notification sent (" + String(len) + " bytes)", true);
+            char nrfHexDump[160] = {0};
+            buildHexDump(nrfHexDump, sizeof(nrfHexDump), "NRF: Sending response: ", response, len);
+            od_log_debug("%s", nrfHexDump);
+            od_log_debug("NRF: BLE notification sent (%u bytes)", len);
         }
         // Bounded retry only when the SoftDevice TX queue is full (notify()==false).
         // Replaces an unconditional delay(20): pays latency only on backpressure and
@@ -253,9 +269,9 @@ void sendResponse(uint8_t* response, uint16_t len) {
             notified = imageCharacteristic.notify(response, len);
         }
     } else {
-        writeSerial("ERROR: Cannot send BLE response - not connected or notifications not enabled", true);
-        writeSerial("  Connected: " + String(Bluefruit.connected() ? "yes" : "no"), true);
-        writeSerial("  Notify enabled: " + String(imageCharacteristic.notifyEnabled() ? "yes" : "no"), true);
+        od_log_error("ERROR: Cannot send BLE response - not connected or notifications not enabled");
+        od_log_error("  Connected: %s", Bluefruit.connected() ? "yes" : "no");
+        od_log_error("  Notify enabled: %s", imageCharacteristic.notifyEnabled() ? "yes" : "no");
     }
 #endif
 }
@@ -268,7 +284,7 @@ void handleReadMSD() {
     memcpy(&response[responseLen], msd_payload, sizeof(msd_payload));
     responseLen += sizeof(msd_payload);
     sendResponse(response, responseLen);
-    writeSerial("MSD read response sent (" + String(responseLen) + " bytes)", true);
+    od_log_debug("MSD read response sent (%u bytes)", responseLen);
 }
 
 uint16_t calculateCRC16CCITT(uint8_t* data, uint32_t len) {
@@ -333,8 +349,8 @@ void handleFirmwareVersion() {
         major = 0;
         minor = 0;
     }
-    writeSerial("Firmware version: " + String(major) + "." + String(minor), true);
-    writeSerial("SHA: " + shaStr, true);
+    od_log_info("Firmware version: %u.%u", major, minor);
+    od_log_info("SHA: %s", shaStr.c_str());
     uint8_t shaLen = shaStr.length();
     if (shaLen > 40) shaLen = 40;
     uint8_t response[2 + 1 + 1 + 1 + 40];
@@ -450,7 +466,7 @@ void handleClearConfig(void) {
         return;
     }
 
-    writeSerial("Stored config cleared");
+    od_log_info("Stored config cleared");
     sendResponse(responseOk, sizeof(responseOk));
 }
 
@@ -542,7 +558,7 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
     (void)conn_hdl;
     (void)chr;
     if (len < 2) {
-        writeSerial("ERROR: Command too short (" + String(len) + " bytes)");
+        od_log_error("ERROR: Command too short (%u bytes)", len);
         return;
     }
 
@@ -556,9 +572,7 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
     if (!quietCmd) {
         const char* name = commandName(command);
         if (name != nullptr) {
-            char banner[64];
-            snprintf(banner, sizeof(banner), "=== %s COMMAND (0x%04X) ===", name, command);
-            writeSerial(banner);
+            od_log_info("=== %s COMMAND (0x%04X) ===", name, command);
         }
     }
 
@@ -576,14 +590,14 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
 
     if (isEncryptionEnabled()) {
         if (!isAuthenticated()) {
-            writeSerial("ERROR: Command requires authentication (encryption enabled)");
+            od_log_error("ERROR: Command requires authentication (encryption enabled)");
             uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
             sendResponseUnencrypted(response, sizeof(response));
             return;
         }
 
         if (len < BLE_CMD_HEADER_SIZE + ENCRYPTION_NONCE_SIZE + ENCRYPTION_TAG_SIZE) {
-            writeSerial("ERROR: Unencrypted command received when encryption is enabled");
+            od_log_error("ERROR: Unencrypted command received when encryption is enabled");
             uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_AUTH_REQUIRED};
             sendResponseUnencrypted(response, sizeof(response));
             return;
@@ -600,21 +614,17 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
         uint16_t encrypted_data_len = len - BLE_CMD_HEADER_SIZE - ENCRYPTION_NONCE_SIZE - ENCRYPTION_TAG_SIZE;
 
         if (!quietCmd) {
-            static char data_buf[256];
-            snprintf(data_buf, sizeof(data_buf), "Encrypted command: len=%u, command=0x%04X, encrypted_data_len=%u",
-                     (unsigned int)len, (unsigned int)command, (unsigned int)encrypted_data_len);
-            writeSerial(data_buf);
-            static char nonce_buf[64];
-            snprintf(nonce_buf, sizeof(nonce_buf), "Full nonce: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
-                     nonce_full[0], nonce_full[1], nonce_full[2], nonce_full[3],
-                     nonce_full[4], nonce_full[5], nonce_full[6], nonce_full[7],
-                     nonce_full[8], nonce_full[9], nonce_full[10], nonce_full[11],
-                     nonce_full[12], nonce_full[13], nonce_full[14], nonce_full[15]);
-            writeSerial(nonce_buf);
+            od_log_debug("Encrypted command: len=%u, command=0x%04X, encrypted_data_len=%u",
+                         (unsigned int)len, (unsigned int)command, (unsigned int)encrypted_data_len);
+            od_log_debug("Full nonce: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+                         nonce_full[0], nonce_full[1], nonce_full[2], nonce_full[3],
+                         nonce_full[4], nonce_full[5], nonce_full[6], nonce_full[7],
+                         nonce_full[8], nonce_full[9], nonce_full[10], nonce_full[11],
+                         nonce_full[12], nonce_full[13], nonce_full[14], nonce_full[15]);
         }
 
         if (!decryptCommand(data + BLE_CMD_HEADER_SIZE + ENCRYPTION_NONCE_SIZE, encrypted_data_len, plaintext, &plaintext_len, nonce_full, auth_tag, command)) {
-            writeSerial("ERROR: Decryption failed");
+            od_log_error("ERROR: Decryption failed");
             uint8_t response[] = {RESP_ACK, (uint8_t)(command & 0xFF), RESP_NACK};
             sendResponseUnencrypted(response, sizeof(response));
             return;
@@ -639,7 +649,6 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             reboot();
             break;
         case CMD_CONFIG_READ:         // 0x0040
-            writeSerial("Command received at time: " + String(millis()));
             handleReadConfig();
             break;
         case CMD_CONFIG_WRITE:        // 0x0041
@@ -698,7 +707,7 @@ void imageDataWritten(BLEConnHandle conn_hdl, BLECharPtr chr, uint8_t* data, uin
             handlePipeWriteEnd(data + 2, len - 2);
             break;
         default:
-            writeSerial("ERROR: Unknown command: 0x" + String(command, HEX));
+            od_log_error("ERROR: Unknown command: 0x%04X", command);
             break;
     }
 }

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -1,6 +1,7 @@
 #include "config_parser.h"
 #include "factory_config.h"
 #include "structs.h"
+#include "od_log.h"
 #include "encryption_state.h"
 #include "encryption.h"
 #include "power_latch.h"
@@ -29,7 +30,6 @@ using namespace Adafruit_LittleFS_Namespace;
 #define DEVICE_FLAG_BATTERY_LATCH (1 << 3)
 #define DEVICE_FLAG_PWR_LATCH_DFF (1 << 4)
 #endif
-void writeSerial(String message, bool newLine = true);
 
 extern struct GlobalConfig globalConfig;
 extern uint8_t activeLedInstance;
@@ -53,14 +53,14 @@ extern bool encryptionInitialized;
 bool initConfigStorage(){
     #ifdef TARGET_NRF
     if (!InternalFS.begin()) {
-        writeSerial("ERROR: Failed to mount internal file system");
+        od_log_error("ERROR: Failed to mount internal file system");
         return false;
     }
     return true;
     #endif
     #ifdef TARGET_ESP32
     if (!LittleFS.begin(true)) { // true = format on failure
-        writeSerial("ERROR: Failed to mount LittleFS");
+        od_log_error("ERROR: Failed to mount LittleFS");
         return false;
     }
     return true;
@@ -79,7 +79,7 @@ void formatConfigStorage(){
 
 bool saveConfig(uint8_t* configData, uint32_t len){
     if (len > MAX_CONFIG_SIZE) {
-        writeSerial("ERROR: Config data too large (" + String(len) + " bytes)");
+        od_log_error("ERROR: Config data too large (%u bytes)", (unsigned)len);
         return false;
     }
     static config_storage_t config;
@@ -102,21 +102,21 @@ bool saveConfig(uint8_t* configData, uint32_t len){
     File file = LittleFS.open(CONFIG_FILE_PATH, FILE_WRITE);
     #endif
     if (!file) {
-        writeSerial("ERROR: Failed to open config file for writing");
+        od_log_error("ERROR: Failed to open config file for writing");
         #ifdef TARGET_NRF
         file = InternalFS.open(CONFIG_FILE_PATH, FILE_O_WRITE);
         #elif defined(TARGET_ESP32)
         file = LittleFS.open(CONFIG_FILE_PATH, FILE_WRITE);
         #endif
         if (!file) {
-            writeSerial("ERROR: Failed to open config file for writing with CREATE|WRITE");
+            od_log_error("ERROR: Failed to open config file for writing with CREATE|WRITE");
         return false;
         }
     }
     size_t bytesWritten = file.write((uint8_t*)&config, totalSize);
     file.close();
     if (bytesWritten != totalSize) {
-        writeSerial("ERROR: Failed to write complete config data (expected " + String(totalSize) + ", wrote " + String(bytesWritten) + ")");
+        od_log_error("ERROR: Failed to write complete config data (expected %u, wrote %u)", (unsigned)totalSize, (unsigned)bytesWritten);
         return false;
     }
     return true;
@@ -126,14 +126,14 @@ bool clearStoredConfig(void) {
     #ifdef TARGET_NRF
     if (InternalFS.exists(CONFIG_FILE_PATH)) {
         if (!InternalFS.remove(CONFIG_FILE_PATH)) {
-            writeSerial("ERROR: Failed to remove config file");
+            od_log_error("ERROR: Failed to remove config file");
             return false;
         }
     }
     #elif defined(TARGET_ESP32)
     if (LittleFS.exists(CONFIG_FILE_PATH)) {
         if (!LittleFS.remove(CONFIG_FILE_PATH)) {
-            writeSerial("ERROR: Failed to remove config file");
+            od_log_error("ERROR: Failed to remove config file");
             return false;
         }
     }
@@ -161,17 +161,17 @@ bool loadConfig(uint8_t* configData, uint32_t* len){
     static size_t headerSize = sizeof(config_storage_t) - MAX_CONFIG_SIZE; // Size without data array
     bytesRead = file.read((uint8_t*)&config, headerSize);
     if (bytesRead != headerSize) {
-        writeSerial("ERROR: Failed to read config header (expected " + String(headerSize) + ", got " + String(bytesRead) + ")");
+        od_log_error("ERROR: Failed to read config header (expected %u, got %u)", (unsigned)headerSize, (unsigned)bytesRead);
         file.close();
         return false;
     }
     if (config.magic != 0xDEADBEEF) {
-        writeSerial("ERROR: Invalid config magic number");
+        od_log_error("ERROR: Invalid config magic number");
         file.close();
         return false;
     }
     if (config.data_len > MAX_CONFIG_SIZE) {
-        writeSerial("ERROR: Config data too large");
+        od_log_error("ERROR: Config data too large");
         file.close();
         return false;
     }
@@ -179,16 +179,16 @@ bool loadConfig(uint8_t* configData, uint32_t* len){
     file.flush();
     file.close();
     if (bytesRead != config.data_len) {
-        writeSerial("ERROR: Failed to read complete config data (expected " + String(config.data_len) + ", read " + String(bytesRead) + ")");
+        od_log_error("ERROR: Failed to read complete config data (expected %u, read %u)", (unsigned)config.data_len, (unsigned)bytesRead);
         return false;
     }
     uint32_t calculatedCRC = calculateConfigCRC(config.data, config.data_len);
     if (config.crc != calculatedCRC) {
-        writeSerial("ERROR: Config CRC mismatch");
+        od_log_error("ERROR: Config CRC mismatch");
         return false;
     }
     if (config.data_len > *len) {
-        writeSerial("ERROR: Config data larger than buffer");
+        od_log_error("ERROR: Config data larger than buffer");
         return false;
     }
     for (uint32_t i = 0; i < config.data_len && i < *len; i++) {
@@ -277,7 +277,7 @@ bool loadGlobalConfig(){
         return false;
     }
     if (configLen < 3) {
-        writeSerial("ERROR: Config too short");
+        od_log_error("ERROR: Config too short");
         globalConfig.loaded = false;
         return false;
     }
@@ -295,7 +295,7 @@ bool loadGlobalConfig(){
                     memcpy(&globalConfig.system_config, &configData[offset], sizeof(struct SystemConfig));
                     offset += sizeof(struct SystemConfig);
                 } else {
-                    writeSerial("ERROR: Not enough data for system_config");
+                    od_log_error("ERROR: Not enough data for system_config");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -305,7 +305,7 @@ bool loadGlobalConfig(){
                     memcpy(&globalConfig.manufacturer_data, &configData[offset], sizeof(struct ManufacturerData));
                     offset += sizeof(struct ManufacturerData);
                 } else {
-                    writeSerial("ERROR: Not enough data for manufacturer_data");
+                    od_log_error("ERROR: Not enough data for manufacturer_data");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -315,7 +315,7 @@ bool loadGlobalConfig(){
                     memcpy(&globalConfig.power_option, &configData[offset], sizeof(struct PowerOption));
                     offset += sizeof(struct PowerOption);
                 } else {
-                    writeSerial("ERROR: Not enough data for power_option");
+                    od_log_error("ERROR: Not enough data for power_option");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -326,10 +326,10 @@ bool loadGlobalConfig(){
                     offset += sizeof(struct DisplayConfig);
                     globalConfig.display_count++;
                 } else if (globalConfig.display_count >= 4) {
-                    writeSerial("WARNING: Maximum display count reached, skipping");
+                    od_log_warn("WARNING: Maximum display count reached, skipping");
                     offset += sizeof(struct DisplayConfig);
                 } else {
-                    writeSerial("ERROR: Not enough data for display");
+                    od_log_error("ERROR: Not enough data for display");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -342,10 +342,10 @@ bool loadGlobalConfig(){
                     // Reset active LED instance to re-detect RGB LEDs after config change
                     activeLedInstance = 0xFF;
                 } else if (globalConfig.led_count >= 4) {
-                    writeSerial("WARNING: Maximum LED count reached, skipping");
+                    od_log_warn("WARNING: Maximum LED count reached, skipping");
                     offset += sizeof(struct LedConfig);
                 } else {
-                    writeSerial("ERROR: Not enough data for LED");
+                    od_log_error("ERROR: Not enough data for LED");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -356,10 +356,10 @@ bool loadGlobalConfig(){
                     offset += sizeof(struct SensorData);
                     globalConfig.sensor_count++;
                 } else if (globalConfig.sensor_count >= 4) {
-                    writeSerial("WARNING: Maximum sensor count reached, skipping");
+                    od_log_warn("WARNING: Maximum sensor count reached, skipping");
                     offset += sizeof(struct SensorData);
                 } else {
-                    writeSerial("ERROR: Not enough data for sensor");
+                    od_log_error("ERROR: Not enough data for sensor");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -370,10 +370,10 @@ bool loadGlobalConfig(){
                     offset += sizeof(struct DataBus);
                     globalConfig.data_bus_count++;
                 } else if (globalConfig.data_bus_count >= 4) {
-                    writeSerial("WARNING: Maximum data_bus count reached, skipping");
+                    od_log_warn("WARNING: Maximum data_bus count reached, skipping");
                     offset += sizeof(struct DataBus);
                 } else {
-                    writeSerial("ERROR: Not enough data for data_bus");
+                    od_log_error("ERROR: Not enough data for data_bus");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -384,10 +384,10 @@ bool loadGlobalConfig(){
                     offset += sizeof(struct BinaryInputs);
                     globalConfig.binary_input_count++;
                 } else if (globalConfig.binary_input_count >= 4) {
-                    writeSerial("WARNING: Maximum binary_input count reached, skipping");
+                    od_log_warn("WARNING: Maximum binary_input count reached, skipping");
                     offset += sizeof(struct BinaryInputs);
                 } else {
-                    writeSerial("ERROR: Not enough data for binary_input");
+                    od_log_error("ERROR: Not enough data for binary_input");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -398,10 +398,10 @@ bool loadGlobalConfig(){
                     offset += sizeof(struct TouchController);
                     globalConfig.touch_controller_count++;
                 } else if (globalConfig.touch_controller_count >= 4) {
-                    writeSerial("WARNING: Maximum touch_controller count reached, skipping");
+                    od_log_warn("WARNING: Maximum touch_controller count reached, skipping");
                     offset += sizeof(struct TouchController);
                 } else {
-                    writeSerial("ERROR: Not enough data for touch_controller");
+                    od_log_error("ERROR: Not enough data for touch_controller");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -412,10 +412,10 @@ bool loadGlobalConfig(){
                     offset += sizeof(struct BuzzerConfig);
                     globalConfig.passive_buzzer_count++;
                 } else if (globalConfig.passive_buzzer_count >= 4) {
-                    writeSerial("WARNING: Maximum passive_buzzer count reached, skipping");
+                    od_log_warn("WARNING: Maximum passive_buzzer count reached, skipping");
                     offset += sizeof(struct BuzzerConfig);
                 } else {
-                    writeSerial("ERROR: Not enough data for passive_buzzer");
+                    od_log_error("ERROR: Not enough data for passive_buzzer");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -435,7 +435,7 @@ bool loadGlobalConfig(){
                     globalConfig.data_extended.custom_string_3[31] = '\0';
                     globalConfig.data_extended_loaded = true;
                 } else {
-                    writeSerial("ERROR: Not enough data for data_extended");
+                    od_log_error("ERROR: Not enough data for data_extended");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -446,10 +446,10 @@ bool loadGlobalConfig(){
                     offset += sizeof(struct FlashConfig);
                     globalConfig.flash_config_count++;
                 } else if (globalConfig.flash_config_count >= 2) {
-                    writeSerial("WARNING: Maximum flash_config count reached, skipping");
+                    od_log_warn("WARNING: Maximum flash_config count reached, skipping");
                     offset += sizeof(struct FlashConfig);
                 } else {
-                    writeSerial("ERROR: Not enough data for flash_config");
+                    od_log_error("ERROR: Not enough data for flash_config");
                     globalConfig.loaded = false;
                     return false;
                 }
@@ -457,7 +457,7 @@ bool loadGlobalConfig(){
             case 0x26: // wifi_config (see struct WifiConfig)
                 {
                     if (offset + sizeof(struct WifiConfig) > configLen - 2) {
-                        writeSerial("ERROR: Not enough data for wifi_config");
+                        od_log_error("ERROR: Not enough data for wifi_config");
                         globalConfig.loaded = false;
                         return false;
                     }
@@ -501,7 +501,7 @@ bool loadGlobalConfig(){
                         ip[2] = wc.server_host[2];
                         ip[3] = wc.server_host[3];
                         snprintf(wifiServerUrl, 65, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
-                        writeSerial("Converted numeric IP to string: \"" + String(wifiServerUrl) + "\"");
+                        od_log_debug("Converted numeric IP to string: \"%s\"", wifiServerUrl);
                     } else if (!isStringFormat && wifiServerUrl[0] != '\0') {
                         uint32_t ipNum = (uint32_t)wc.server_host[0] |
                                         ((uint32_t)wc.server_host[1] << 8) |
@@ -513,7 +513,7 @@ bool loadGlobalConfig(){
                         ip[2] = (ipNum >> 8) & 0xFF;
                         ip[3] = ipNum & 0xFF;
                         snprintf(wifiServerUrl, 65, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
-                        writeSerial("Converted 32-bit integer to IP string: \"" + String(wifiServerUrl) + "\"");
+                        od_log_debug("Converted 32-bit integer to IP string: \"%s\"", wifiServerUrl);
                     }
 
                     // server_port is the one BIG-ENDIAN field in WifiConfig; read it byte-wise
@@ -527,27 +527,27 @@ bool loadGlobalConfig(){
                     wifiServerConfigured = (wifiServerUrl[0] != '\0' &&
                                            strcmp(wifiServerUrl, "0.0.0.0") != 0);
                     if (wifiServerConfigured) {
-                        writeSerial("Server configured: YES");
-                        writeSerial("Server URL: \"" + String(wifiServerUrl) + "\"");
-                        writeSerial("Server Port: " + String(wifiServerPort));
+                        od_log_debug("Server configured: YES");
+                        od_log_debug("Server URL: \"%s\"", wifiServerUrl);
+                        od_log_debug("Server Port: %u", wifiServerPort);
                     } else {
-                        writeSerial("Server configured: NO");
+                        od_log_debug("Server configured: NO");
                         if (wifiServerUrl[0] == '\0') {
-                            writeSerial("Reason: URL is empty");
+                            od_log_debug("Reason: URL is empty");
                         } else if (strcmp(wifiServerUrl, "0.0.0.0") == 0) {
-                            writeSerial("Reason: URL is \"0.0.0.0\"");
+                            od_log_debug("Reason: URL is \"0.0.0.0\"");
                         }
                     }
 #endif
                     wifiConfigured = true;
-                    writeSerial("=== WiFi Configuration Loaded ===");
-                    writeSerial("SSID: \"" + String(wifiSsid) + "\"");
+                    od_log_info("=== WiFi Configuration Loaded ===");
+                    od_log_debug("SSID: \"%s\"", wifiSsid);
                     if (passwordLen > 0) {
-                        writeSerial("Password: \"" + String(wifiPassword) + "\"");
+                        od_log_debug("Password: \"%s\"", wifiPassword);
                     } else {
-                        writeSerial("Password: (empty)");
+                        od_log_debug("Password: (empty)");
                     }
-                    String encTypeStr = "Unknown";
+                    const char* encTypeStr = "Unknown";
                     switch (wifiEncryptionType) {
                         case 0x00: encTypeStr = "None (Open)"; break;
                         case 0x01: encTypeStr = "WEP"; break;
@@ -555,10 +555,10 @@ bool loadGlobalConfig(){
                         case 0x03: encTypeStr = "WPA2"; break;
                         case 0x04: encTypeStr = "WPA3"; break;
                     }
-                    writeSerial("Encryption Type: 0x" + String(wifiEncryptionType, HEX) + " (" + encTypeStr + ")");
-                    writeSerial("SSID length: " + String(ssidLen) + " bytes");
-                    writeSerial("Password length: " + String(passwordLen) + " bytes");
-                    writeSerial("WiFi configured: true");
+                    od_log_debug("Encryption Type: 0x%02X (%s)", wifiEncryptionType, encTypeStr);
+                    od_log_debug("SSID length: %u bytes", ssidLen);
+                    od_log_debug("Password length: %u bytes", passwordLen);
+                    od_log_debug("WiFi configured: true");
                 }
                 break;
             case 0x27: // security_config
@@ -576,37 +576,38 @@ bool loadGlobalConfig(){
                         }
                         if (keyIsZero) {
                             securityConfig.encryption_enabled = 0;
-                            writeSerial("Security config: Encryption disabled (key is all zeros)");
+                            od_log_debug("Security config: Encryption disabled (key is all zeros)");
                         } else if (securityConfig.encryption_enabled) {
-                            writeSerial("Security config: Encryption enabled");
-                            writeSerial("Session timeout: " + String(securityConfig.session_timeout_seconds) + " seconds");
+                            od_log_debug("Security config: Encryption enabled");
+                            od_log_debug("Session timeout: %u seconds", securityConfig.session_timeout_seconds);
                         } else {
-                            writeSerial("Security config: Encryption disabled (flag set to 0)");
+                            od_log_debug("Security config: Encryption disabled (flag set to 0)");
                         }
                         // Log security flags
                         if (securityConfig.flags & OD_SECURITY_FLAG_REWRITE_ALLOWED) {
-                            writeSerial("Security config: Rewrite allowed (unauthorized config writes permitted)");
+                            od_log_debug("Security config: Rewrite allowed (unauthorized config writes permitted)");
                         }
                         if (securityConfig.flags & OD_SECURITY_FLAG_SHOW_KEY_ON_SCREEN) {
-                            writeSerial("Security config: Show key on screen enabled (future feature)");
+                            od_log_debug("Security config: Show key on screen enabled (future feature)");
                         }
                         if (securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_ENABLED) {
-                            writeSerial("Security config: Reset pin " + String(securityConfig.reset_pin) + 
-                                       " enabled (polarity: " + String((securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_POLARITY) ? "HIGH" : "LOW") + 
-                                       ", pullup: " + String((securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_PULLUP) ? "yes" : "no") + 
-                                       ", pulldown: " + String((securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_PULLDOWN) ? "yes" : "no") + ")");
+                            od_log_debug("Security config: Reset pin %u enabled (polarity: %s, pullup: %s, pulldown: %s)",
+                                       securityConfig.reset_pin,
+                                       (securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_POLARITY) ? "HIGH" : "LOW",
+                                       (securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_PULLUP) ? "yes" : "no",
+                                       (securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_PULLDOWN) ? "yes" : "no");
                         } else {
-                            writeSerial("Security config: Reset pin disabled");
+                            od_log_debug("Security config: Reset pin disabled");
                         }
                     } else {
-                        writeSerial("ERROR: Not enough data for security_config");
+                        od_log_error("ERROR: Not enough data for security_config");
                         globalConfig.loaded = false;
                         return false;
                     }
                 }
                 break;
             default:
-                writeSerial("WARNING: Unknown packet ID 0x" + String(packetId, HEX) + ", skipping");
+                od_log_warn("WARNING: Unknown packet ID 0x%02X, skipping", packetId);
                 offset = configLen - 2; // Skip to CRC
                 break;
         }
@@ -617,8 +618,7 @@ bool loadGlobalConfig(){
         // nRF and Silabs firmware. Not enforced: a mismatch logs a warning only.
         uint16_t crcCalculated = config_toolbox_outer_crc16(configData, configLen - 2);
         if (crcGiven != crcCalculated) {
-            writeSerial("WARNING: Config CRC mismatch (given: 0x" + String(crcGiven, HEX) + 
-                       ", calculated: 0x" + String(crcCalculated, HEX) + ")");
+            od_log_warn("WARNING: Config CRC mismatch (given: 0x%04X, calculated: 0x%04X)", crcGiven, crcCalculated);
         }
     }
     globalConfig.loaded = true;
@@ -627,225 +627,233 @@ bool loadGlobalConfig(){
 
 void printConfigSummary(){
     if (!globalConfig.loaded) {
-        writeSerial("Config not loaded");
+        od_log_debug("Config not loaded");
         return;
     }
-    writeSerial("=== Configuration Summary ===");
-    writeSerial("Version: " + String(globalConfig.version) + "." + String(globalConfig.minor_version));
-    writeSerial("Loaded: " + String(globalConfig.loaded ? "Yes" : "No"));
-    writeSerial("");
-    writeSerial("--- System Configuration ---");
-    writeSerial("IC Type: 0x" + String(globalConfig.system_config.ic_type, HEX));
-    writeSerial("Communication Modes: 0x" + String(globalConfig.system_config.communication_modes, HEX));
-    writeSerial("  BLE: " + String((globalConfig.system_config.communication_modes & COMM_MODE_BLE) ? "enabled" : "disabled"));
-    writeSerial("  OEPL: " + String((globalConfig.system_config.communication_modes & COMM_MODE_OEPL) ? "enabled" : "disabled"));
-    writeSerial("  WiFi: " + String((globalConfig.system_config.communication_modes & COMM_MODE_WIFI) ? "enabled" : "disabled"));
+    od_log_debug("=== Configuration Summary ===");
+    od_log_debug("Version: %u.%u", globalConfig.version, globalConfig.minor_version);
+    od_log_debug("Loaded: %s", globalConfig.loaded ? "Yes" : "No");
+    od_log_debug(" ");
+    od_log_debug("--- System Configuration ---");
+    od_log_debug("IC Type: 0x%04X", globalConfig.system_config.ic_type);
+    od_log_debug("Communication Modes: 0x%02X", globalConfig.system_config.communication_modes);
+    od_log_debug("  BLE: %s", (globalConfig.system_config.communication_modes & COMM_MODE_BLE) ? "enabled" : "disabled");
+    od_log_debug("  OEPL: %s", (globalConfig.system_config.communication_modes & COMM_MODE_OEPL) ? "enabled" : "disabled");
+    od_log_debug("  WiFi: %s", (globalConfig.system_config.communication_modes & COMM_MODE_WIFI) ? "enabled" : "disabled");
     #ifdef TARGET_ESP32
     if (globalConfig.system_config.communication_modes & COMM_MODE_WIFI) {
         if (wifiConfigured) {
-            writeSerial("  WiFi SSID: \"" + String(wifiSsid) + "\"");
+            od_log_debug("  WiFi SSID: \"%s\"", wifiSsid);
             if (wifiInitialized) {
                 if (wifiConnected) {
-                    writeSerial("  WiFi Status: Connected (IP: " + WiFi.localIP().toString() + ")");
+                    String localIp = WiFi.localIP().toString();
+                    od_log_debug("  WiFi Status: Connected (IP: %s)", localIp.c_str());
                 } else {
-                    writeSerial("  WiFi Status: Disconnected");
+                    od_log_debug("  WiFi Status: Disconnected");
                 }
             } else {
-                writeSerial("  WiFi Status: Not initialized");
+                od_log_debug("  WiFi Status: Not initialized");
             }
         } else {
-            writeSerial("  WiFi Status: Configured but not loaded");
+            od_log_debug("  WiFi Status: Configured but not loaded");
         }
     }
     #endif
-    writeSerial("Device Flags: 0x" + String(globalConfig.system_config.device_flags, HEX));
-    writeSerial("  PWR_PIN flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_PWR_PIN) ? "enabled" : "disabled"));
+    od_log_debug("Device Flags: 0x%02X", globalConfig.system_config.device_flags);
+    od_log_debug("  PWR_PIN flag: %s", (globalConfig.system_config.device_flags & DEVICE_FLAG_PWR_PIN) ? "enabled" : "disabled");
     #ifdef TARGET_NRF
-    writeSerial("  XIAOINIT flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_XIAOINIT) ? "enabled" : "disabled"));
+    od_log_debug("  XIAOINIT flag: %s", (globalConfig.system_config.device_flags & DEVICE_FLAG_XIAOINIT) ? "enabled" : "disabled");
     #endif
-    writeSerial("  WS_PP_INIT flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_WS_PP_INIT) ? "enabled" : "disabled"));
-    writeSerial("  BATTERY_LATCH flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_BATTERY_LATCH) ? "enabled" : "disabled"));
-    writeSerial("  PWR_LATCH_DFF flag: " + String((globalConfig.system_config.device_flags & DEVICE_FLAG_PWR_LATCH_DFF) ? "enabled" : "disabled"));
-    writeSerial("Power Pin: " + String(globalConfig.system_config.pwr_pin));
-    writeSerial("Power Pin 2: " + String(globalConfig.system_config.pwr_pin_2));
-    writeSerial("Power Pin 3: " + String(globalConfig.system_config.pwr_pin_3));
-    writeSerial("");
-    writeSerial("--- Manufacturer Data ---");
-    writeSerial("Manufacturer ID: 0x" + String(globalConfig.manufacturer_data.manufacturer_id, HEX));
-    writeSerial("Board Type: " + String(globalConfig.manufacturer_data.board_type));
-    writeSerial("Board Revision: " + String(globalConfig.manufacturer_data.board_revision));
-    writeSerial("");
-    writeSerial("--- Power Configuration ---");
-    writeSerial("Power Mode: " + String(globalConfig.power_option.power_mode));
-    writeSerial("Battery Capacity: " + String(globalConfig.power_option.battery_capacity_mah[0]) + 
-               " " + String(globalConfig.power_option.battery_capacity_mah[1]) + 
-               " " + String(globalConfig.power_option.battery_capacity_mah[2]) + " mAh");
-    writeSerial("Awake Timeout: " + String(globalConfig.power_option.sleep_timeout_ms) + " ms");
-    writeSerial("Deep Sleep Time: " + String(globalConfig.power_option.deep_sleep_time_seconds) + " seconds");
-    writeSerial("Min Wake Time: " + String(globalConfig.power_option.min_wake_time_seconds) + " seconds");
-    writeSerial("TX Power: " + String(globalConfig.power_option.tx_power));
-    writeSerial("Sleep Flags: 0x" + String(globalConfig.power_option.sleep_flags, HEX));
-    writeSerial("Button Wake: " + String((globalConfig.power_option.sleep_flags & OD_SLEEP_FLAG_BUTTON_WAKE_DISABLE) ? "disabled" : "enabled") + " (sleep_flags bit0)");
-    writeSerial("Screen Timeout: " + String(globalConfig.power_option.screen_timeout_seconds) + " s (EPD keep-alive; 0 = off immediately after refresh)");
-    writeSerial("Battery Sense Pin: " + String(globalConfig.power_option.battery_sense_pin));
-    writeSerial("Battery Sense Enable Pin: " + String(globalConfig.power_option.battery_sense_enable_pin));
-    writeSerial("Battery Sense Flags: 0x" + String(globalConfig.power_option.battery_sense_flags, HEX));
-    writeSerial("  ENABLE_INVERTED: " + String((globalConfig.power_option.battery_sense_flags & OD_BATTERY_SENSE_FLAG_ENABLE_INVERTED) ? "yes" : "no"));
-    writeSerial("Capacity Estimator: " + String(globalConfig.power_option.capacity_estimator));
-    writeSerial("Voltage Scaling Factor: " + String(globalConfig.power_option.voltage_scaling_factor));
-    writeSerial("Deep Sleep Current: " + String(globalConfig.power_option.deep_sleep_current_ua) + " uA");
-    writeSerial("");
-    writeSerial("--- Display Configurations (" + String(globalConfig.display_count) + ") ---");
+    od_log_debug("  WS_PP_INIT flag: %s", (globalConfig.system_config.device_flags & DEVICE_FLAG_WS_PP_INIT) ? "enabled" : "disabled");
+    od_log_debug("  BATTERY_LATCH flag: %s", (globalConfig.system_config.device_flags & DEVICE_FLAG_BATTERY_LATCH) ? "enabled" : "disabled");
+    od_log_debug("  PWR_LATCH_DFF flag: %s", (globalConfig.system_config.device_flags & DEVICE_FLAG_PWR_LATCH_DFF) ? "enabled" : "disabled");
+    od_log_debug("Power Pin: %u", globalConfig.system_config.pwr_pin);
+    od_log_debug("Power Pin 2: %u", globalConfig.system_config.pwr_pin_2);
+    od_log_debug("Power Pin 3: %u", globalConfig.system_config.pwr_pin_3);
+    od_log_debug(" ");
+    od_log_debug("--- Manufacturer Data ---");
+    od_log_debug("Manufacturer ID: 0x%04X", globalConfig.manufacturer_data.manufacturer_id);
+    od_log_debug("Board Type: %u", globalConfig.manufacturer_data.board_type);
+    od_log_debug("Board Revision: %u", globalConfig.manufacturer_data.board_revision);
+    od_log_debug(" ");
+    od_log_debug("--- Power Configuration ---");
+    od_log_debug("Power Mode: %u", globalConfig.power_option.power_mode);
+    od_log_debug("Battery Capacity: %u %u %u mAh",
+               globalConfig.power_option.battery_capacity_mah[0],
+               globalConfig.power_option.battery_capacity_mah[1],
+               globalConfig.power_option.battery_capacity_mah[2]);
+    od_log_debug("Awake Timeout: %u ms", globalConfig.power_option.sleep_timeout_ms);
+    od_log_debug("Deep Sleep Time: %u seconds", globalConfig.power_option.deep_sleep_time_seconds);
+    od_log_debug("Min Wake Time: %u seconds", globalConfig.power_option.min_wake_time_seconds);
+    od_log_debug("TX Power: %u", globalConfig.power_option.tx_power);
+    od_log_debug("Sleep Flags: 0x%02X", globalConfig.power_option.sleep_flags);
+    od_log_debug("Button Wake: %s (sleep_flags bit0)", (globalConfig.power_option.sleep_flags & OD_SLEEP_FLAG_BUTTON_WAKE_DISABLE) ? "disabled" : "enabled");
+    od_log_debug("Screen Timeout: %u s (EPD keep-alive; 0 = off immediately after refresh)", globalConfig.power_option.screen_timeout_seconds);
+    od_log_debug("Battery Sense Pin: %u", globalConfig.power_option.battery_sense_pin);
+    od_log_debug("Battery Sense Enable Pin: %u", globalConfig.power_option.battery_sense_enable_pin);
+    od_log_debug("Battery Sense Flags: 0x%02X", globalConfig.power_option.battery_sense_flags);
+    od_log_debug("  ENABLE_INVERTED: %s", (globalConfig.power_option.battery_sense_flags & OD_BATTERY_SENSE_FLAG_ENABLE_INVERTED) ? "yes" : "no");
+    od_log_debug("Capacity Estimator: %u", globalConfig.power_option.capacity_estimator);
+    od_log_debug("Voltage Scaling Factor: %u", globalConfig.power_option.voltage_scaling_factor);
+    od_log_debug("Deep Sleep Current: %u uA", (unsigned)globalConfig.power_option.deep_sleep_current_ua);
+    od_log_debug(" ");
+    od_log_debug("--- Display Configurations (%u) ---", globalConfig.display_count);
     for (int i = 0; i < globalConfig.display_count; i++) {
-        writeSerial("Display " + String(i) + ":");
-        writeSerial("  Instance: " + String(globalConfig.displays[i].instance_number));
-        writeSerial("  Technology: 0x" + String(globalConfig.displays[i].display_technology, HEX));
-        writeSerial("  Panel IC Type: 0x" + String(globalConfig.displays[i].panel_ic_type, HEX));
-        writeSerial("  Resolution: " + String(globalConfig.displays[i].pixel_width) + "x" + String(globalConfig.displays[i].pixel_height));
-        writeSerial("  Size: " + String(globalConfig.displays[i].active_width_mm) + "x" + String(globalConfig.displays[i].active_height_mm) + " mm");
-        writeSerial("  Tag Type: 0x" + String(globalConfig.displays[i].legacy_tag_type, HEX));
-        writeSerial("  Rotation: " + String(globalConfig.displays[i].rotation * 90) + " degrees");
-        writeSerial("  Reset Pin: " + String(globalConfig.displays[i].reset_pin));
-        writeSerial("  Busy Pin: " + String(globalConfig.displays[i].busy_pin));
-        writeSerial("  DC Pin: " + String(globalConfig.displays[i].dc_pin));
-        writeSerial("  CS Pin: " + String(globalConfig.displays[i].cs_pin));
-        writeSerial("  Data Pin: " + String(globalConfig.displays[i].data_pin));
-        writeSerial("  Partial Update: " + String(globalConfig.displays[i].partial_update_support ? "Yes" : "No"));
-        writeSerial("  Color Scheme: 0x" + String(globalConfig.displays[i].color_scheme, HEX));
-        writeSerial("  Transmission Modes: 0x" + String(globalConfig.displays[i].transmission_modes, HEX));
-        writeSerial("    ZIPXL: " + String((globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_STREAMING_DECOMPRESSION) ? "enabled" : "disabled"));
-        writeSerial("    ZIP: " + String((globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_ZIP) ? "enabled" : "disabled"));
-        writeSerial("    G5: " + String((globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_G5) ? "enabled" : "disabled"));
-        writeSerial("    DIRECT_WRITE: " + String((globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_DIRECT_WRITE) ? "enabled" : "disabled"));
-        writeSerial("    CLEAR_ON_BOOT: " + String((globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_CLEAR_ON_BOOT) ? "enabled" : "disabled"));
-        writeSerial("  Full update energy (mC): " + String(globalConfig.displays[i].full_update_mC));
-        writeSerial("");
+        od_log_debug("Display %d:", i);
+        od_log_debug("  Instance: %u", globalConfig.displays[i].instance_number);
+        od_log_debug("  Technology: 0x%02X", globalConfig.displays[i].display_technology);
+        od_log_debug("  Panel IC Type: 0x%04X", globalConfig.displays[i].panel_ic_type);
+        od_log_debug("  Resolution: %ux%u", globalConfig.displays[i].pixel_width, globalConfig.displays[i].pixel_height);
+        od_log_debug("  Size: %ux%u mm", globalConfig.displays[i].active_width_mm, globalConfig.displays[i].active_height_mm);
+        od_log_debug("  Tag Type: 0x%04X", globalConfig.displays[i].legacy_tag_type);
+        od_log_debug("  Rotation: %u degrees", (unsigned)(globalConfig.displays[i].rotation * 90));
+        od_log_debug("  Reset Pin: %u", globalConfig.displays[i].reset_pin);
+        od_log_debug("  Busy Pin: %u", globalConfig.displays[i].busy_pin);
+        od_log_debug("  DC Pin: %u", globalConfig.displays[i].dc_pin);
+        od_log_debug("  CS Pin: %u", globalConfig.displays[i].cs_pin);
+        od_log_debug("  Data Pin: %u", globalConfig.displays[i].data_pin);
+        od_log_debug("  Partial Update: %s", globalConfig.displays[i].partial_update_support ? "Yes" : "No");
+        od_log_debug("  Color Scheme: 0x%02X", globalConfig.displays[i].color_scheme);
+        od_log_debug("  Transmission Modes: 0x%02X", globalConfig.displays[i].transmission_modes);
+        od_log_debug("    ZIPXL: %s", (globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_STREAMING_DECOMPRESSION) ? "enabled" : "disabled");
+        od_log_debug("    ZIP: %s", (globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_ZIP) ? "enabled" : "disabled");
+        od_log_debug("    G5: %s", (globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_G5) ? "enabled" : "disabled");
+        od_log_debug("    DIRECT_WRITE: %s", (globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_DIRECT_WRITE) ? "enabled" : "disabled");
+        od_log_debug("    CLEAR_ON_BOOT: %s", (globalConfig.displays[i].transmission_modes & OD_TRANSMISSION_MODE_CLEAR_ON_BOOT) ? "enabled" : "disabled");
+        od_log_debug("  Full update energy (mC): %u", globalConfig.displays[i].full_update_mC);
+        od_log_debug(" ");
     }
-    writeSerial("--- LED Configurations (" + String(globalConfig.led_count) + ") ---");
+    od_log_debug("--- LED Configurations (%u) ---", globalConfig.led_count);
     for (int i = 0; i < globalConfig.led_count; i++) {
-        writeSerial("LED " + String(i) + ":");
-        writeSerial("  Instance: " + String(globalConfig.leds[i].instance_number));
-        writeSerial("  Type: 0x" + String(globalConfig.leds[i].led_type, HEX));
-        writeSerial("  Pins: R=" + String(globalConfig.leds[i].led_1_r) + 
-                   " G=" + String(globalConfig.leds[i].led_2_g) + 
-                   " B=" + String(globalConfig.leds[i].led_3_b) + 
-                   " 4=" + String(globalConfig.leds[i].led_4));
-        writeSerial("  Flags: 0x" + String(globalConfig.leds[i].led_flags, HEX));
-        writeSerial("");
+        od_log_debug("LED %d:", i);
+        od_log_debug("  Instance: %u", globalConfig.leds[i].instance_number);
+        od_log_debug("  Type: 0x%02X", globalConfig.leds[i].led_type);
+        od_log_debug("  Pins: R=%u G=%u B=%u 4=%u",
+                   globalConfig.leds[i].led_1_r,
+                   globalConfig.leds[i].led_2_g,
+                   globalConfig.leds[i].led_3_b,
+                   globalConfig.leds[i].led_4);
+        od_log_debug("  Flags: 0x%02X", globalConfig.leds[i].led_flags);
+        od_log_debug(" ");
     }
-    writeSerial("--- Sensor Configurations (" + String(globalConfig.sensor_count) + ") ---");
+    od_log_debug("--- Sensor Configurations (%u) ---", globalConfig.sensor_count);
     for (int i = 0; i < globalConfig.sensor_count; i++) {
-        writeSerial("Sensor " + String(i) + ":");
-        writeSerial("  Instance: " + String(globalConfig.sensors[i].instance_number));
-        writeSerial("  Type: 0x" + String(globalConfig.sensors[i].sensor_type, HEX));
-        writeSerial("  Bus ID: " + String(globalConfig.sensors[i].bus_id));
-        writeSerial("  I2C addr (7-bit) / MSD data start byte: " + String(globalConfig.sensors[i].i2c_addr_7bit) + " / " + String(globalConfig.sensors[i].msd_data_start_byte));
-        writeSerial("");
+        od_log_debug("Sensor %d:", i);
+        od_log_debug("  Instance: %u", globalConfig.sensors[i].instance_number);
+        od_log_debug("  Type: 0x%04X", globalConfig.sensors[i].sensor_type);
+        od_log_debug("  Bus ID: %u", globalConfig.sensors[i].bus_id);
+        od_log_debug("  I2C addr (7-bit) / MSD data start byte: %u / %u", globalConfig.sensors[i].i2c_addr_7bit, globalConfig.sensors[i].msd_data_start_byte);
+        od_log_debug(" ");
     }
-    writeSerial("--- Data Bus Configurations (" + String(globalConfig.data_bus_count) + ") ---");
+    od_log_debug("--- Data Bus Configurations (%u) ---", globalConfig.data_bus_count);
     for (int i = 0; i < globalConfig.data_bus_count; i++) {
-        writeSerial("Data Bus " + String(i) + ":");
-        writeSerial("  Instance: " + String(globalConfig.data_buses[i].instance_number));
-        writeSerial("  Type: 0x" + String(globalConfig.data_buses[i].bus_type, HEX));
-        writeSerial("  Pins: 1=" + String(globalConfig.data_buses[i].pin_1) + 
-                   " 2=" + String(globalConfig.data_buses[i].pin_2) + 
-                   " 3=" + String(globalConfig.data_buses[i].pin_3) + 
-                   " 4=" + String(globalConfig.data_buses[i].pin_4) + 
-                   " 5=" + String(globalConfig.data_buses[i].pin_5) + 
-                   " 6=" + String(globalConfig.data_buses[i].pin_6) + 
-                   " 7=" + String(globalConfig.data_buses[i].pin_7));
-        writeSerial("  Speed: " + String(globalConfig.data_buses[i].bus_speed_hz) + " Hz");
-        writeSerial("  Flags: 0x" + String(globalConfig.data_buses[i].bus_flags, HEX));
-        writeSerial("  Pullups: 0x" + String(globalConfig.data_buses[i].pullups, HEX));
-        writeSerial("  Pulldowns: 0x" + String(globalConfig.data_buses[i].pulldowns, HEX));
-        writeSerial("");
+        od_log_debug("Data Bus %d:", i);
+        od_log_debug("  Instance: %u", globalConfig.data_buses[i].instance_number);
+        od_log_debug("  Type: 0x%02X", globalConfig.data_buses[i].bus_type);
+        od_log_debug("  Pins: 1=%u 2=%u 3=%u 4=%u 5=%u 6=%u 7=%u",
+                   globalConfig.data_buses[i].pin_1,
+                   globalConfig.data_buses[i].pin_2,
+                   globalConfig.data_buses[i].pin_3,
+                   globalConfig.data_buses[i].pin_4,
+                   globalConfig.data_buses[i].pin_5,
+                   globalConfig.data_buses[i].pin_6,
+                   globalConfig.data_buses[i].pin_7);
+        od_log_debug("  Speed: %u Hz", (unsigned)globalConfig.data_buses[i].bus_speed_hz);
+        od_log_debug("  Flags: 0x%02X", globalConfig.data_buses[i].bus_flags);
+        od_log_debug("  Pullups: 0x%02X", globalConfig.data_buses[i].pullups);
+        od_log_debug("  Pulldowns: 0x%02X", globalConfig.data_buses[i].pulldowns);
+        od_log_debug(" ");
     }
-    writeSerial("--- Binary Input Configurations (" + String(globalConfig.binary_input_count) + ") ---");
+    od_log_debug("--- Binary Input Configurations (%u) ---", globalConfig.binary_input_count);
     for (int i = 0; i < globalConfig.binary_input_count; i++) {
-        writeSerial("Binary Input " + String(i) + ":");
-        writeSerial("  Instance: " + String(globalConfig.binary_inputs[i].instance_number));
-        writeSerial("  Type: 0x" + String(globalConfig.binary_inputs[i].input_type, HEX));
-        writeSerial("  Display As: 0x" + String(globalConfig.binary_inputs[i].display_as, HEX));
-        writeSerial("  Pins: 1=" + String(globalConfig.binary_inputs[i].input_pin_1) +
-                   " 2=" + String(globalConfig.binary_inputs[i].input_pin_2) +
-                   " 3=" + String(globalConfig.binary_inputs[i].input_pin_3) +
-                   " 4=" + String(globalConfig.binary_inputs[i].input_pin_4) +
-                   " 5=" + String(globalConfig.binary_inputs[i].input_pin_5) +
-                   " 6=" + String(globalConfig.binary_inputs[i].input_pin_6) +
-                   " 7=" + String(globalConfig.binary_inputs[i].input_pin_7) +
-                   " 8=" + String(globalConfig.binary_inputs[i].input_pin_8));
-        writeSerial("  Input Flags: 0x" + String(globalConfig.binary_inputs[i].pins_used, HEX));
-        writeSerial("  Invert: 0x" + String(globalConfig.binary_inputs[i].invert, HEX));
-        writeSerial("  Pullups: 0x" + String(globalConfig.binary_inputs[i].pullups, HEX));
-        writeSerial("  Pulldowns: 0x" + String(globalConfig.binary_inputs[i].pulldowns, HEX));
+        od_log_debug("Binary Input %d:", i);
+        od_log_debug("  Instance: %u", globalConfig.binary_inputs[i].instance_number);
+        od_log_debug("  Type: 0x%02X", globalConfig.binary_inputs[i].input_type);
+        od_log_debug("  Display As: 0x%02X", globalConfig.binary_inputs[i].display_as);
+        od_log_debug("  Pins: 1=%u 2=%u 3=%u 4=%u 5=%u 6=%u 7=%u 8=%u",
+                   globalConfig.binary_inputs[i].input_pin_1,
+                   globalConfig.binary_inputs[i].input_pin_2,
+                   globalConfig.binary_inputs[i].input_pin_3,
+                   globalConfig.binary_inputs[i].input_pin_4,
+                   globalConfig.binary_inputs[i].input_pin_5,
+                   globalConfig.binary_inputs[i].input_pin_6,
+                   globalConfig.binary_inputs[i].input_pin_7,
+                   globalConfig.binary_inputs[i].input_pin_8);
+        od_log_debug("  Input Flags: 0x%02X", globalConfig.binary_inputs[i].pins_used);
+        od_log_debug("  Invert: 0x%02X", globalConfig.binary_inputs[i].invert);
+        od_log_debug("  Pullups: 0x%02X", globalConfig.binary_inputs[i].pullups);
+        od_log_debug("  Pulldowns: 0x%02X", globalConfig.binary_inputs[i].pulldowns);
         if (globalConfig.binary_inputs[i].input_type == 3) {
-            writeSerial("  ADC Ladder: count=" + String(globalConfig.binary_inputs[i].reserved[0]) +
-                        " idBase=" + String(globalConfig.binary_inputs[i].reserved[1]) +
-                        " byteIdx=" + String(globalConfig.binary_inputs[i].button_data_byte_index));
+            od_log_debug("  ADC Ladder: count=%u idBase=%u byteIdx=%u",
+                        globalConfig.binary_inputs[i].reserved[0],
+                        globalConfig.binary_inputs[i].reserved[1],
+                        globalConfig.binary_inputs[i].button_data_byte_index);
         }
-        writeSerial("");
+        od_log_debug(" ");
     }
-    writeSerial("--- Touch Controllers (" + String(globalConfig.touch_controller_count) + ") ---");
+    od_log_debug("--- Touch Controllers (%u) ---", globalConfig.touch_controller_count);
     for (int i = 0; i < globalConfig.touch_controller_count; i++) {
-        writeSerial("Touch " + String(i) + ":");
-        writeSerial("  Instance: " + String(globalConfig.touch_controllers[i].instance_number));
-        writeSerial("  IC type: " + String(globalConfig.touch_controllers[i].touch_ic_type));
-        writeSerial("  Bus ID: " + String(globalConfig.touch_controllers[i].bus_id));
-        writeSerial("  I2C addr (7-bit): 0x" + String(globalConfig.touch_controllers[i].i2c_addr_7bit, HEX));
-        writeSerial("  INT/RST/EN pins: " + String(globalConfig.touch_controllers[i].int_pin) + " / " +
-                    String(globalConfig.touch_controllers[i].rst_pin) + " / " + String(globalConfig.touch_controllers[i].enable_pin));
-        writeSerial("  Display instance: " + String(globalConfig.touch_controllers[i].display_instance));
-        writeSerial("  Flags: 0x" + String(globalConfig.touch_controllers[i].flags, HEX));
-        writeSerial("  Poll ms / MSD start byte: " + String(globalConfig.touch_controllers[i].poll_interval_ms) + " / " + String(globalConfig.touch_controllers[i].touch_data_start_byte));
-        writeSerial("");
+        od_log_debug("Touch %d:", i);
+        od_log_debug("  Instance: %u", globalConfig.touch_controllers[i].instance_number);
+        od_log_debug("  IC type: %u", globalConfig.touch_controllers[i].touch_ic_type);
+        od_log_debug("  Bus ID: %u", globalConfig.touch_controllers[i].bus_id);
+        od_log_debug("  I2C addr (7-bit): 0x%02X", globalConfig.touch_controllers[i].i2c_addr_7bit);
+        od_log_debug("  INT/RST/EN pins: %u / %u / %u",
+                    globalConfig.touch_controllers[i].int_pin,
+                    globalConfig.touch_controllers[i].rst_pin,
+                    globalConfig.touch_controllers[i].enable_pin);
+        od_log_debug("  Display instance: %u", globalConfig.touch_controllers[i].display_instance);
+        od_log_debug("  Flags: 0x%02X", globalConfig.touch_controllers[i].flags);
+        od_log_debug("  Poll ms / MSD start byte: %u / %u", globalConfig.touch_controllers[i].poll_interval_ms, globalConfig.touch_controllers[i].touch_data_start_byte);
+        od_log_debug(" ");
     }
-    writeSerial("--- Passive buzzers (" + String(globalConfig.passive_buzzer_count) + ") ---");
+    od_log_debug("--- Passive buzzers (%u) ---", globalConfig.passive_buzzer_count);
     for (int i = 0; i < globalConfig.passive_buzzer_count; i++) {
-        writeSerial("Buzzer " + String(i) + ":");
-        writeSerial("  Instance: " + String(globalConfig.passive_buzzers[i].instance_number));
-        writeSerial("  Drive / enable pin: " + String(globalConfig.passive_buzzers[i].drive_pin) + " / " + String(globalConfig.passive_buzzers[i].enable_pin));
-        writeSerial("  Flags: 0x" + String(globalConfig.passive_buzzers[i].flags, HEX));
-        writeSerial("  Duty %: " + String(globalConfig.passive_buzzers[i].duty_percent));
-        writeSerial("");
+        od_log_debug("Buzzer %d:", i);
+        od_log_debug("  Instance: %u", globalConfig.passive_buzzers[i].instance_number);
+        od_log_debug("  Drive / enable pin: %u / %u", globalConfig.passive_buzzers[i].drive_pin, globalConfig.passive_buzzers[i].enable_pin);
+        od_log_debug("  Flags: 0x%02X", globalConfig.passive_buzzers[i].flags);
+        od_log_debug("  Duty %%: %u", globalConfig.passive_buzzers[i].duty_percent);
+        od_log_debug(" ");
     }
     if (globalConfig.data_extended_loaded) {
-        writeSerial("--- Data Extended ---");
-        writeSerial("  manufacturer_name: " + String((char*)globalConfig.data_extended.manufacturer_name));
-        writeSerial("  model_name: "        + String((char*)globalConfig.data_extended.model_name));
-        writeSerial("  serial_number: "     + String((char*)globalConfig.data_extended.serial_number));
-        writeSerial("  friendly_name: "     + String((char*)globalConfig.data_extended.friendly_name));
-        writeSerial("  device_location: "   + String((char*)globalConfig.data_extended.device_location));
-        writeSerial("  device_id: "         + String((char*)globalConfig.data_extended.device_id));
-        writeSerial("  custom_string_1: "   + String((char*)globalConfig.data_extended.custom_string_1));
-        writeSerial("  custom_string_2: "   + String((char*)globalConfig.data_extended.custom_string_2));
-        writeSerial("  custom_string_3: "   + String((char*)globalConfig.data_extended.custom_string_3));
-        writeSerial("");
+        od_log_debug("--- Data Extended ---");
+        od_log_debug("  manufacturer_name: %s", (char*)globalConfig.data_extended.manufacturer_name);
+        od_log_debug("  model_name: %s",        (char*)globalConfig.data_extended.model_name);
+        od_log_debug("  serial_number: %s",     (char*)globalConfig.data_extended.serial_number);
+        od_log_debug("  friendly_name: %s",     (char*)globalConfig.data_extended.friendly_name);
+        od_log_debug("  device_location: %s",   (char*)globalConfig.data_extended.device_location);
+        od_log_debug("  device_id: %s",         (char*)globalConfig.data_extended.device_id);
+        od_log_debug("  custom_string_1: %s",   (char*)globalConfig.data_extended.custom_string_1);
+        od_log_debug("  custom_string_2: %s",   (char*)globalConfig.data_extended.custom_string_2);
+        od_log_debug("  custom_string_3: %s",   (char*)globalConfig.data_extended.custom_string_3);
+        od_log_debug(" ");
     }
-    writeSerial("=============================");
+    od_log_debug("=============================");
 }
 
 void full_config_init() {
-    writeSerial("Initializing config storage...");
+    od_log_info("Initializing config storage...");
     if (!initConfigStorage()) {
-        writeSerial("Config storage initialization failed");
+        od_log_error("Config storage initialization failed");
         return;
     }
-    writeSerial("Config storage initialized successfully");
+    od_log_info("Config storage initialized successfully");
 
 #ifdef FACTORY_CLEAR_CONFIG_ON_BOOT
-    writeSerial("Factory clear build: erasing stored config");
+    od_log_info("Factory clear build: erasing stored config");
     clearStoredConfig();
-    writeSerial("Config cleared; skipping load");
+    od_log_info("Config cleared; skipping load");
     return;
 #endif
 
-    writeSerial("Loading global configuration...");
+    od_log_info("Loading global configuration...");
     bool configLoaded = loadGlobalConfig();
     if (!configLoaded && tryProvisionFactoryEmbed()) {
         configLoaded = loadGlobalConfig();
     }
     if (configLoaded) {
-        writeSerial("Global configuration loaded successfully");
+        od_log_info("Global configuration loaded successfully");
         printConfigSummary();
         clearEncryptionSession();
         encryptionInitialized = true;
@@ -853,19 +861,19 @@ void full_config_init() {
 #ifdef TARGET_NRF
         powerDownExternalFlashFromConfig();
         if (globalConfig.loaded && (globalConfig.system_config.device_flags & DEVICE_FLAG_XIAOINIT)) {
-            writeSerial("Device flag DEVICE_FLAG_XIAOINIT is set, calling xiaoinit()...");
+            od_log_info("Device flag DEVICE_FLAG_XIAOINIT is set, calling xiaoinit()...");
             xiaoinit();
-            writeSerial("xiaoinit() completed");
+            od_log_info("xiaoinit() completed");
         }
 #endif
         if (globalConfig.loaded && (globalConfig.system_config.device_flags & DEVICE_FLAG_WS_PP_INIT)) {
-            writeSerial("Device flag DEVICE_FLAG_WS_PP_INIT is set, calling ws_pp_init()...");
+            od_log_info("Device flag DEVICE_FLAG_WS_PP_INIT is set, calling ws_pp_init()...");
             ws_pp_init();
-            writeSerial("ws_pp_init() completed");
+            od_log_info("ws_pp_init() completed");
         }
         // Must run after config load: latch pins/flag come from globalConfig.
         powerLatchBegin();
     } else {
-        writeSerial("Global configuration load failed or no config found");
+        od_log_error("Global configuration load failed or no config found");
     }
 }

--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -3,6 +3,7 @@
 #include "touch_input.h"
 #include "power_latch.h"
 #include "buzzer_control.h"
+#include "od_log.h"
 #include <string.h>
 
 #ifdef TARGET_ESP32
@@ -39,7 +40,6 @@ void cleanupDirectWriteState(bool refreshDisplay);
 void cleanupPartialWriteOnDisconnect(void);
 void resetPipeWriteState(void);
 void sendResponse(uint8_t* response, uint16_t len);
-void writeSerial(String message, bool newLine = true);
 
 extern ButtonState buttonStates[MAX_BUTTONS];
 
@@ -128,18 +128,18 @@ static void registerAdcLadder(const struct BinaryInputs* input) {
     if (adcLadderCount >= MAX_ADC_LADDERS) return;
     uint8_t n = input->reserved[0];                        // num_buttons
     if (n == 0 || n > MAX_LADDER_BUTTONS) {
-        writeSerial("ADC ladder: count " + String(n) + " out of range 1.." +
-                    String(MAX_LADDER_BUTTONS) + " on pin " + String(input->input_pin_1) + ", skipping", true);
+        od_log_warn("ADC ladder: count %u out of range 1..%u on pin %u, skipping",
+                    n, MAX_LADDER_BUTTONS, input->input_pin_1);
         return;
     }
     if (input->button_data_byte_index > 10) {              // index into the 11-byte MSD block
-        writeSerial("ADC ladder: byte_index " + String(input->button_data_byte_index) +
-                    " out of range 0..10 on pin " + String(input->input_pin_1) + ", skipping", true);
+        od_log_warn("ADC ladder: byte_index %u out of range 0..10 on pin %u, skipping",
+                    input->button_data_byte_index, input->input_pin_1);
         return;
     }
     if ((int)input->reserved[1] + n > 8) {                 // 3-bit id field: id_base..id_base+n-1 must be <= 7
-        writeSerial("ADC ladder: id_base " + String(input->reserved[1]) + " + count " + String(n) +
-                    " exceeds 3-bit id space on pin " + String(input->input_pin_1) + ", skipping", true);
+        od_log_warn("ADC ladder: id_base %u + count %u exceeds 3-bit id space on pin %u, skipping",
+                    input->reserved[1], n, input->input_pin_1);
         return;
     }
     AdcLadder* l = &adcLadders[adcLadderCount];
@@ -153,8 +153,7 @@ static void registerAdcLadder(const struct BinaryInputs* input) {
     }
     for (uint8_t k = 0; k < n; k++) {                      // contract: thresholds strictly descending
         if (l->thresholds[k] <= l->thresholds[k + 1]) {    // reject malformed config from any host
-            writeSerial("ADC ladder: thresholds not strictly descending on pin " +
-                        String(input->input_pin_1) + ", skipping", true);
+            od_log_warn("ADC ladder: thresholds not strictly descending on pin %u, skipping", input->input_pin_1);
             return;
         }
     }
@@ -167,8 +166,7 @@ static void registerAdcLadder(const struct BinaryInputs* input) {
     pinMode(l->pin, INPUT);
     analogSetPinAttenuation(l->pin, ADC_11db);
     adcLadderCount++;
-    writeSerial("ADC ladder: pin " + String(l->pin) + " n " + String(n) +
-                " idBase " + String(l->id_base) + " byteIdx " + String(l->byte_index), true);
+    od_log_info("ADC ladder: pin %u n %u idBase %u byteIdx %u", l->pin, n, l->id_base, l->byte_index);
 }
 
 static void pollAdcButtons() {
@@ -205,9 +203,8 @@ static void pollAdcButtons() {
                                  ((state & 0x01) << 7));
         if (l->byte_index < 11) dynamicreturndata[l->byte_index] = data;
         updatemsdata();
-        writeSerial("ADC btn pin " + String(l->pin) + " adc=" + String(adc) + " idx=" + String(btn) +
-                    " id=" + String(l->last_button_id) + " cnt=" + String(l->press_count) +
-                    " state=" + String(state), true);
+        od_log_debug("ADC btn pin %u adc=%d idx=%d id=%u cnt=%u state=%u",
+                    l->pin, adc, btn, l->last_button_id, l->press_count, state);
     }
 }
 #else
@@ -216,7 +213,7 @@ static void pollAdcButtons() {}
 
 void connect_callback(uint16_t conn_handle) {
     (void)conn_handle;
-    writeSerial("=== BLE CLIENT CONNECTED ===", true);
+    od_log_info("=== BLE CLIENT CONNECTED ===");
     rebootFlag = 0;
     updatemsdata();
 #ifdef TARGET_NRF
@@ -229,8 +226,8 @@ void connect_callback(uint16_t conn_handle) {
 void disconnect_callback(uint16_t conn_handle, uint8_t reason) {
     (void)conn_handle;
     (void)reason;
-    writeSerial("=== BLE CLIENT DISCONNECTED ===", true);
-    writeSerial("Disconnect reason: " + String(reason), true);
+    od_log_info("=== BLE CLIENT DISCONNECTED ===");
+    od_log_info("Disconnect reason: %u", reason);
     // Panel power on disconnect follows the ACTIVE-only-teardown invariant, so no
     // logic change is needed here: a WARM (post-successful-refresh) panel SURVIVES
     // disconnect and keeps its keep-alive window — a reconnect within the window
@@ -256,7 +253,7 @@ static void esp32_ble_deinit_before_restart() {
     BLEDevice::deinit(true);      // clearAll: disables + releases the BT controller
     esp32_ble_clear_handles();
     delay(100);
-    writeSerial("BLE deinitialized before restart", true);
+    od_log_info("BLE deinitialized before restart");
 }
 #endif
 
@@ -591,15 +588,15 @@ void processButtonEvents() {
         uint8_t changedButtonIndex = lastChangedButtonIndex;
         lastChangedButtonIndex = 0xFF;
         interrupts();
-        writeSerial("Button event pending: " + String(changedButtonIndex));
+        od_log_debug("Button event pending: %u", changedButtonIndex);
         if (changedButtonIndex < MAX_BUTTONS && buttonStates[changedButtonIndex].initialized) {
             ButtonState* btn = &buttonStates[changedButtonIndex];
             bool pinState = digitalRead(btn->pin);
             bool logicalPressed = btn->inverted ? !pinState : pinState;
-            writeSerial("Pin state: " + String(pinState) + ", Logical pressed: " + String(logicalPressed) + ",inverted: " + String(btn->inverted));
+            od_log_debug("Pin state: %d, Logical pressed: %d, inverted: %d", pinState, logicalPressed, btn->inverted);
             uint8_t logicalState = logicalPressed ? 1 : 0;
             btn->current_state = logicalState;
-            writeSerial("Button: " + String(btn->button_id) + ", Press count: " + String(btn->press_count) + ", Current state: " + String(btn->current_state));
+            od_log_debug("Button: %u, Press count: %u, Current state: %u", btn->button_id, btn->press_count, btn->current_state);
             uint8_t buttonData = (btn->button_id & 0x07) |
                                  ((btn->press_count & 0x0F) << 3) |
                                  ((btn->current_state & 0x01) << 7);
@@ -712,7 +709,7 @@ void buttonISRGeneric() {
 #endif
 
 void initButtons() {
-    writeSerial("=== Initializing Buttons ===");
+    od_log_info("=== Initializing Buttons ===");
     buttonStateCount = 0;
     for (uint8_t i = 0; i < MAX_BUTTONS; i++) {
         buttonStates[i].initialized = false;
@@ -751,7 +748,7 @@ void initButtons() {
             uint8_t pin = *instancePins[pinIdx];
             if (pin == 0xFF) continue;
             if (touch_input_gpio_is_touch_int(pin)) {
-                writeSerial("Button: skip pin " + String(pin) + " (reserved for GT911 INT)", true);
+                od_log_debug("Button: skip pin %u (reserved for GT911 INT)", pin);
                 continue;
             }
             if (buttonStateCount >= MAX_BUTTONS) break;
@@ -833,12 +830,12 @@ void enterDFUMode() {
     // Banner logged by the dispatcher (commandName() in communication.cpp).
 
 #ifdef TARGET_NRF
-    writeSerial("Preparing to enter DFU bootloader mode...", true);
+    od_log_info("Preparing to enter DFU bootloader mode...");
 
     Bluefruit.Advertising.restartOnDisconnect(false);
 
     if (Bluefruit.connected()) {
-        writeSerial("Disconnecting BLE...", true);
+        od_log_info("Disconnecting BLE...");
         Bluefruit.disconnect(Bluefruit.connHandle());
         delay(100);
     }
@@ -863,7 +860,7 @@ void enterDFUMode() {
 #endif
 
 #ifdef TARGET_ESP32
-    writeSerial("ESP32: Rebooting (OTA typically handled via WiFi)", true);
+    od_log_info("ESP32: Rebooting (OTA typically handled via WiFi)");
     delay(100);
     esp32_ble_deinit_before_restart();
     esp_restart();
@@ -880,7 +877,7 @@ void handleDeepSleepCommand(const uint8_t* payload, uint16_t payloadLen) {
         overrideSeconds = ((uint16_t)payload[0] << 8) | payload[1];
         // Bytes beyond 2 ignored for forward compatibility.
     } else if (payloadLen == 1) {
-        writeSerial("WARNING: malformed 0x" + String(CMD_DEEP_SLEEP, HEX) + " payload length 1 - ignoring", true);
+        od_log_warn("WARNING: malformed 0x%04X payload length 1 - ignoring", CMD_DEEP_SLEEP);
     }
     // Enforce a 60 s floor on host overrides: a very short wake timer risks a rapid
     // sleep/wake churn that never stays awake long enough to service a client. This
@@ -888,18 +885,17 @@ void handleDeepSleepCommand(const uint8_t* payload, uint16_t payloadLen) {
     // to the configured deep_sleep_time_seconds, which is not subject to this floor.
     constexpr uint16_t MIN_DEEP_SLEEP_OVERRIDE_SECONDS = 60;
     if (overrideSeconds != 0 && overrideSeconds < MIN_DEEP_SLEEP_OVERRIDE_SECONDS) {
-        writeSerial("Override " + String(overrideSeconds) + "s below " +
-                    String(MIN_DEEP_SLEEP_OVERRIDE_SECONDS) + "s floor - clamping", true);
+        od_log_warn("Override %us below %us floor - clamping", overrideSeconds, MIN_DEEP_SLEEP_OVERRIDE_SECONDS);
         overrideSeconds = MIN_DEEP_SLEEP_OVERRIDE_SECONDS;
     }
     if (globalConfig.power_option.power_mode != 1) {
-        writeSerial("Device not battery powered - 0x" + String(CMD_DEEP_SLEEP, HEX) + " rejected", true);
+        od_log_warn("Device not battery powered - 0x%04X rejected", CMD_DEEP_SLEEP);
         uint8_t errorResponse[] = {RESP_NACK, RESP_DEEP_SLEEP, OD_ERR_DEEP_SLEEP_NOT_BATTERY, 0x00};
         sendResponse(errorResponse, sizeof(errorResponse));
         return;
     }
     if (globalConfig.power_option.deep_sleep_time_seconds == 0) {
-        writeSerial("Deep sleep disabled in config - 0x" + String(CMD_DEEP_SLEEP, HEX) + " rejected", true);
+        od_log_warn("Deep sleep disabled in config - 0x%04X rejected", CMD_DEEP_SLEEP);
         uint8_t errorResponse[] = {RESP_NACK, RESP_DEEP_SLEEP, OD_ERR_DEEP_SLEEP_DISABLED, 0x00};
         sendResponse(errorResponse, sizeof(errorResponse));
         return;
@@ -912,7 +908,7 @@ void handleDeepSleepCommand(const uint8_t* payload, uint16_t payloadLen) {
     // silent to preserve existing behavior — leave as-is unless a caller needs the NACK.
     (void)payload;
     (void)payloadLen;
-    writeSerial("Deep sleep command not supported on this target", true);
+    od_log_warn("Deep sleep command not supported on this target");
 #endif
 }
 
@@ -948,7 +944,7 @@ void handlePowerOffCommand(const uint8_t* payload, uint16_t payloadLen) {
     //      sleep a device that cannot self-repower.
     // Until that lands: capability-gated NACK. Scope: OD_ERR_POWER_OFF_* only — do NOT
     // conflate with 0x53 deep sleep (a device that refuses 0x52 may still accept 0x53).
-    writeSerial("No power latch on this target - 0x" + String(CMD_POWER_OFF, HEX) + " rejected", true);
+    od_log_warn("No power latch on this target - 0x%04X rejected", CMD_POWER_OFF);
     uint8_t errorResponse[] = {RESP_NACK, RESP_POWER_OFF, OD_ERR_POWER_OFF_UNSUPPORTED, 0x00};
     sendResponse(errorResponse, sizeof(errorResponse));
 }

--- a/src/display_service.cpp
+++ b/src/display_service.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <Wire.h>
 #include "structs.h"
+#include "od_log.h"
 #include "buzzer_control.h"
 #include "sensor_sht40.h"
 #include "sensor_bq27220.h"
@@ -105,8 +106,6 @@ extern BLEService* pService;
 
 void pwrmgm(bool onoff);
 String getChipIdHex();
-void writeSerial(String message, bool newLine);
-void flushLog();
 void bbepInitIO(BBEPDISP *pBBEP, uint8_t u8DC, uint8_t u8RST, uint8_t u8BUSY, uint8_t u8CS, uint8_t u8MOSI, uint8_t u8SCK, uint32_t u32Speed);
 void bbepWakeUp(BBEPDISP *pBBEP);
 void bbepSendCMDSequence(BBEPDISP *pBBEP, const uint8_t *pSeq);
@@ -364,7 +363,7 @@ static uint32_t epdKeepAliveWindowMs(void) {
     for (uint8_t i = 0; i < globalConfig.sensor_count; i++) {
         if (globalConfig.sensors[i].sensor_type == OD_SENSOR_TYPE_AXP2101) {
             if (s != 0) {
-                writeSerial("[EPD session] AXP2101 present - keep-alive forced off (screen_timeout_seconds ignored)", true);
+                od_log_info("[EPD session] AXP2101 present - keep-alive forced off (screen_timeout_seconds ignored)");
             }
             return 0;
         }
@@ -396,7 +395,7 @@ static void pwrmgmLockGive(void) {
 // power off without re-taking the non-recursive lock.
 static void epdSessionForceOffLocked(void) {
     if (pwrmgmState == PWR_OFF) return;   // idempotent
-    writeSerial("[EPD session] force off", true);
+    od_log_info("[EPD session] force off");
     if (epdSessionUsesFastepd()) {
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_FASTEPD)
         fastepd_direct_sleep();
@@ -418,7 +417,7 @@ static bool epdSessionAcquire(bool partialInit) {
     pwrmgmLockTake();
     bool cold;
     if (pwrmgmState == PWR_OFF) {
-        writeSerial("[EPD session] acquire: COLD bring-up", true);
+        od_log_info("[EPD session] acquire: COLD bring-up");
         pwrmgm(true);   // -> PWR_ACTIVE (guarded; real transition)
         if (!epdSessionUsesFastepd()) {
             const DisplayConfig& d = globalConfig.displays[0];
@@ -441,8 +440,8 @@ static bool epdSessionAcquire(bool partialInit) {
         cold = true;
     } else {
         // WARM re-acquire (or, defensively, an already-ACTIVE re-entry).
-        writeSerial(pwrmgmState == PWR_ACTIVE ? "[EPD session] acquire: already ACTIVE (defensive)"
-                                              : "[EPD session] acquire: WARM re-acquire", true);
+        od_log_info(pwrmgmState == PWR_ACTIVE ? "[EPD session] acquire: already ACTIVE (defensive)"
+                                              : "[EPD session] acquire: WARM re-acquire");
         pwrmgmState = PWR_ACTIVE;
         pwrmgmOffDeadlineMs = 0;   // cancel keep-alive
         // Phase 1: full re-init on warm re-acquire (HW reset => registers identical
@@ -476,14 +475,14 @@ static void epdSessionRelease(bool refreshSuccess) {
     if (pwrmgmState == PWR_OFF) { pwrmgmLockGive(); return; }   // nothing to release
     uint32_t window = epdKeepAliveWindowMs();
     if (window == 0 || !refreshSuccess) {
-        writeSerial(refreshSuccess ? "[EPD session] release: keep-alive disabled, powering off"
-                                   : "[EPD session] release: refresh failed, powering off", true);
+        od_log_info(refreshSuccess ? "[EPD session] release: keep-alive disabled, powering off"
+                                   : "[EPD session] release: refresh failed, powering off");
         epdSessionForceOffLocked();
     } else {
         pwrmgmState = PWR_WARM;
         pwrmgmOffDeadlineMs = millis() + window;
         // Controller stays AWAKE (no bbepSleep; is_awake stays 1); rail/SPI stay up.
-        writeSerial("[EPD session] release: panel warm-idle, off in " + String(window) + " ms", true);
+        od_log_info("[EPD session] release: panel warm-idle, off in %u ms", (unsigned)window);
     }
     pwrmgmLockGive();
 }
@@ -499,7 +498,7 @@ void epdSessionTick(void) {
     if (!pwrmgmLockTryTake()) return;      // held by a transfer -> skip this pass
     // Re-check under the lock: a transfer may have moved us out of WARM meanwhile.
     if (pwrmgmState == PWR_WARM && (int32_t)(millis() - pwrmgmOffDeadlineMs) >= 0) {
-        writeSerial("[EPD session] keep-alive expired — powering panel off", true);
+        od_log_info("[EPD session] keep-alive expired — powering panel off");
         epdSessionForceOffLocked();
     }
     pwrmgmLockGive();
@@ -511,10 +510,10 @@ bool epdSessionIsWarm(void) {
 
 static bool refreshBootScreenFull() {
     if (!writeBootScreenWithQr()) {
-        writeSerial("Boot screen render failed", true);
+        od_log_warn("Boot screen render failed");
         return false;
     }
-    writeSerial("EPD refresh: FULL (boot)", true);
+    od_log_info("EPD refresh: FULL (boot)");
     touchSuspendForEpdRefresh();
     bbepRefresh(&bbep, REFRESH_FULL);
     return waitforrefresh(60);
@@ -550,7 +549,7 @@ static PipeReorderSlot pipeReorder[PIPE_REORDER_SLOTS];
 void checkPartialWriteTimeout(void) {
     if (partialCtx.active && partialCtx.start_time > 0 &&
         (millis() - partialCtx.start_time) > 900000UL) {
-        writeSerial("ERROR: Partial write timeout - cleaning up stuck state", true);
+        od_log_error("ERROR: Partial write timeout - cleaning up stuck state");
         cleanup_partial_write_state();
         // A pipe-partial transfer shares partialCtx: also clear pipeState so a zombie
         // pipeState.active can't misroute later 0x0081 frames into the dead partialCtx.
@@ -722,7 +721,7 @@ bool waitforrefresh(int timeout){
 #endif
     if (e1004_panel_used() && !bbepIsBusy(&bbep)) {
         // bbepRefresh already waited; idle here means refresh finished.
-        writeSerial("Refresh completed inside bb_epaper", true);
+        od_log_info("Refresh completed inside bb_epaper");
         return true;
     }
     // Poll at 10 ms (was 100 ms) so a ~0.5 s refresh returns up to ~90 ms sooner.
@@ -731,21 +730,19 @@ bool waitforrefresh(int timeout){
     // (timeout*100 iterations of 10 ms); dot cadence every 50 iters keeps ~0.5 s/dot.
     for (size_t i = 0; i < (size_t)(timeout * 100); i++){
         delay(10);
-        if(i % 50 == 0) writeSerial(".", false);
+        if(i % 50 == 0) od_log_raw(".");
         if(!bbepIsBusy(&bbep)){
             if(i == 0){
-                writeSerial("ERROR: Epaper not busy after refresh command - refresh may not have started", true);
+                od_log_error("ERROR: Epaper not busy after refresh command - refresh may not have started");
                 return false;
             }
-            writeSerial(".", true);
-            writeSerial("Refresh took ", false);
-            writeSerial((String)((float)i / 100), false);
-            writeSerial(" seconds", true);
+            od_log_raw(".\n");
+            od_log_info("Refresh took %.2f seconds", (float)i / 100);
 //            delay(200);   // EXTRA DELAY HERE IS UNNEEDED AND JUST SLOWS THINGS DOWN
             return true;
         }
     }
-    writeSerial("Refresh timed out", true);
+    od_log_warn("Refresh timed out");
     return false;
 }
 
@@ -766,7 +763,7 @@ static bool wireBeginForOpenDisplay(int sda, int scl, uint32_t hz) {
         return true;
     }
     if (hz > 100000u && Wire.begin(sda, scl, 100000u)) {
-        writeSerial("NOTE: I2C fallback to 100kHz (SDA=GPIO" + String(sda) + " SCL=GPIO" + String(scl) + ")", true);
+        od_log_info("NOTE: I2C fallback to 100kHz (SDA=GPIO%d SCL=GPIO%d)", sda, scl);
         Wire.setClock(100000u);
         s_wire_sda_pin = (int8_t)sda;
         s_wire_scl_pin = (int8_t)scl;
@@ -774,7 +771,7 @@ static bool wireBeginForOpenDisplay(int sda, int scl, uint32_t hz) {
         s_wire_open_display_ready = true;
         return true;
     }
-    writeSerial("ERROR: Wire.begin failed (SDA=GPIO" + String(sda) + " SCL=GPIO" + String(scl) + ")", true);
+    od_log_error("ERROR: Wire.begin failed (SDA=GPIO%d SCL=GPIO%d)", sda, scl);
     return false;
 }
 #endif
@@ -864,17 +861,17 @@ void initOrRestoreWireForOpenDisplay(void) {
 }
 
 void initDataBuses(){
-    writeSerial("=== Initializing Data Buses ===", true);
+    od_log_info("=== Initializing Data Buses ===");
     if(globalConfig.data_bus_count == 0){
-        writeSerial("No data buses configured", true);
+        od_log_info("No data buses configured");
         return;
     }
     for(uint8_t i = 0; i < globalConfig.data_bus_count; i++){
         struct DataBus* bus = &globalConfig.data_buses[i];
         if(bus->bus_type == 0x01){ // I2C bus
-            writeSerial("Initializing I2C bus " + String(i) + " (instance " + String(bus->instance_number) + ")", true);
+            od_log_info("Initializing I2C bus %u (instance %u)", i, bus->instance_number);
             if(bus->pin_1 == 0xFF || bus->pin_2 == 0xFF){
-                writeSerial("ERROR: Invalid I2C pins for bus " + String(i) + " (SCL=" + String(bus->pin_1) + ", SDA=" + String(bus->pin_2) + ")", true);
+                od_log_error("ERROR: Invalid I2C pins for bus %u (SCL=%u, SDA=%u)", i, bus->pin_1, bus->pin_2);
                 continue;
             }
             uint32_t busSpeed = (bus->bus_speed_hz > 0) ? bus->bus_speed_hz : 100000;
@@ -893,27 +890,27 @@ void initDataBuses(){
                 }
                 Wire.begin(); // Uses default I2C pins
                 Wire.setClock(busSpeed);
-                writeSerial("NOTE: nRF52840 using default I2C pins (config pins: SCL=" + String(bus->pin_1) + ", SDA=" + String(bus->pin_2) + ")", true);
+                od_log_info("NOTE: nRF52840 using default I2C pins (config pins: SCL=%u, SDA=%u)", bus->pin_1, bus->pin_2);
                 #endif
-                writeSerial("I2C bus " + String(i) + " initialized: SCL=pin" + String(bus->pin_1) + ", SDA=pin" + String(bus->pin_2) + ", Speed=" + String(busSpeed) + "Hz", true);
+                od_log_info("I2C bus %u initialized: SCL=pin%u, SDA=pin%u, Speed=%uHz", i, bus->pin_1, bus->pin_2, (unsigned)busSpeed);
             } else {
-                writeSerial("I2C bus " + String(i) + " configured (init on demand): SCL=pin" + String(bus->pin_1) +
-                    ", SDA=pin" + String(bus->pin_2) + ", Speed=" + String(busSpeed) + "Hz", true);
+                od_log_info("I2C bus %u configured (init on demand): SCL=pin%u, SDA=pin%u, Speed=%uHz",
+                    i, bus->pin_1, bus->pin_2, (unsigned)busSpeed);
             }
         }
         else if(bus->bus_type == 0x02){
-            writeSerial("SPI bus " + String(i) + " detected (not yet implemented)", true);
-            writeSerial("  Instance: " + String(bus->instance_number), true);
+            od_log_info("SPI bus %u detected (not yet implemented)", i);
+            od_log_info("  Instance: %u", bus->instance_number);
         }
         else{
-            writeSerial("WARNING: Unknown bus type 0x" + String(bus->bus_type, HEX) + " for bus " + String(i), true);
+            od_log_warn("WARNING: Unknown bus type 0x%02X for bus %u", bus->bus_type, i);
         }
     }
-    writeSerial("=== Data Bus Initialization Complete ===", true);
+    od_log_info("=== Data Bus Initialization Complete ===");
 }
 
 void initio(){
-    writeSerial("[initio] >> LEDs", true); flushLog();
+    od_log_info("[initio] >> LEDs"); od_log_flush();
     if(globalConfig.led_count > 0){
         for (uint8_t i = 0; i < globalConfig.led_count; i++) {
             struct LedConfig* led = &globalConfig.leds[i];
@@ -953,25 +950,25 @@ void initio(){
             }
         }
     }
-    writeSerial("[initio] >> initPassiveBuzzers", true); flushLog();
+    od_log_info("[initio] >> initPassiveBuzzers"); od_log_flush();
     initPassiveBuzzers();
-    writeSerial("[initio] >> pwr_pin", true); flushLog();
+    od_log_info("[initio] >> pwr_pin"); od_log_flush();
     if(globalConfig.system_config.pwr_pin != 0xFF){
     pinMode(globalConfig.system_config.pwr_pin, OUTPUT);
     digitalWrite(globalConfig.system_config.pwr_pin, LOW);
     }
     else{
-        writeSerial("Power pin not set", true);
+        od_log_warn("Power pin not set");
     }
-    writeSerial("[initio] >> initDataBuses", true); flushLog();
+    od_log_info("[initio] >> initDataBuses"); od_log_flush();
     initDataBuses();
-    writeSerial("[initio] >> initSensors", true); flushLog();
+    od_log_info("[initio] >> initSensors"); od_log_flush();
     initSensors();
-    writeSerial("[initio] << done", true); flushLog();
+    od_log_info("[initio] << done"); od_log_flush();
 }
 
 void scanI2CDevices(){
-    writeSerial("=== Scanning I2C Bus for Devices ===", true);
+    od_log_info("=== Scanning I2C Bus for Devices ===");
     initOrRestoreWireForOpenDisplay();
     uint8_t deviceCount = 0;
     uint8_t foundDevices[128];
@@ -981,60 +978,68 @@ void scanI2CDevices(){
         if(error == 0){
             foundDevices[deviceCount] = address;
             deviceCount++;
-            writeSerial("I2C device found at address 0x" + String(address, HEX) + " (" + String(address) + ")", true);
+            od_log_debug("I2C device found at address 0x%02X (%u)", address, address);
         }
         else if(error == 4){
-            writeSerial("ERROR: Unknown error at address 0x" + String(address, HEX), true);
+            od_log_error("ERROR: Unknown error at address 0x%02X", address);
         }
     }
     if(deviceCount == 0){
-        writeSerial("No I2C devices found on bus", true);
+        od_log_warn("No I2C devices found on bus");
     } else {
-        writeSerial("Found " + String(deviceCount) + " I2C device(s)", true);
-        writeSerial("Device addresses: ", true);
-        String addrList = "";
-        for(uint8_t i = 0; i < deviceCount; i++){
-            if(i > 0) addrList += ", ";
-            addrList += "0x" + String(foundDevices[i], HEX);
+        od_log_debug("Found %u I2C device(s)", deviceCount);
+        od_log_debug("Device addresses: ");
+        char addrList[700];
+        int pos = snprintf(addrList, sizeof(addrList), "%s", "");
+        if (pos < 0) {
+            pos = 0;
+            addrList[0] = '\0';
         }
-        writeSerial(addrList, true);
+        for(uint8_t i = 0; i < deviceCount && pos < (int)sizeof(addrList); i++){
+            int n = snprintf(addrList + pos, sizeof(addrList) - pos, i > 0 ? ", 0x%02X" : "0x%02X", foundDevices[i]);
+            if (n < 0) {
+                break;
+            }
+            pos += n;
+        }
+        od_log_debug("%s", addrList);
     }
-    writeSerial("=== I2C Scan Complete ===", true);
+    od_log_info("=== I2C Scan Complete ===");
 }
 
 void initSensors(){
-    writeSerial("=== Initializing Sensors ===", true);
+    od_log_info("=== Initializing Sensors ===");
     if(globalConfig.sensor_count == 0){
-        writeSerial("No sensors configured", true);
+        od_log_warn("No sensors configured");
         return;
     }
     for(uint8_t i = 0; i < globalConfig.sensor_count; i++){
         struct SensorData* sensor = &globalConfig.sensors[i];
-        writeSerial("Initializing sensor " + String(i) + " (instance " + String(sensor->instance_number) + ")", true);
-        writeSerial("  Type: 0x" + String(sensor->sensor_type, HEX), true);
-        writeSerial("  Bus ID: " + String(sensor->bus_id), true);
+        od_log_debug("Initializing sensor %u (instance %u)", i, sensor->instance_number);
+        od_log_debug("  Type: 0x%04X", sensor->sensor_type);
+        od_log_debug("  Bus ID: %u", sensor->bus_id);
         if(sensor->sensor_type == OD_SENSOR_TYPE_AXP2101){
-            writeSerial("  Detected AXP2101 PMIC sensor", true);
+            od_log_debug("  Detected AXP2101 PMIC sensor");
         }
         else if(sensor->sensor_type == OD_SENSOR_TYPE_TEMPERATURE){
-            writeSerial("  Temperature sensor (initialization not implemented)", true);
+            od_log_debug("  Temperature sensor (initialization not implemented)");
         }
         else if(sensor->sensor_type == OD_SENSOR_TYPE_HUMIDITY){
-            writeSerial("  Humidity sensor (initialization not implemented)", true);
+            od_log_debug("  Humidity sensor (initialization not implemented)");
         }
         else if(sensor->sensor_type == OD_SENSOR_TYPE_SHT40){
-            writeSerial("  SHT40 (I2C + MSD slot)", true);
+            od_log_debug("  SHT40 (I2C + MSD slot)");
         }
         else if(sensor->sensor_type == OD_SENSOR_TYPE_BQ27220){
-            writeSerial("  BQ27220 fuel gauge (MSD voltage + optional dynamic SOC/status bytes)", true);
+            od_log_debug("  BQ27220 fuel gauge (MSD voltage + optional dynamic SOC/status bytes)");
         }
         else{
-            writeSerial("  Unknown sensor type 0x" + String(sensor->sensor_type, HEX), true);
+            od_log_warn("  Unknown sensor type 0x%04X", sensor->sensor_type);
         }
     }
     initSht40Sensors();
     initBq27220Sensors();
-    writeSerial("=== Sensor Initialization Complete ===", true);
+    od_log_info("=== Sensor Initialization Complete ===");
 }
 
 void initAXP2101(uint8_t busId){
@@ -1042,27 +1047,27 @@ void initAXP2101(uint8_t busId){
     digitalWrite(21, LOW);
     delay(100);
     digitalWrite(21, HIGH);
-    writeSerial("=== Initializing AXP2101 PMIC ===", true);
+    od_log_info("=== Initializing AXP2101 PMIC ===");
     if(busId >= globalConfig.data_bus_count){
-        writeSerial("ERROR: Invalid bus ID " + String(busId) + " (only " + String(globalConfig.data_bus_count) + " buses configured)", true);
+        od_log_error("ERROR: Invalid bus ID %u (only %u buses configured)", busId, globalConfig.data_bus_count);
         return;
     }
     struct DataBus* bus = &globalConfig.data_buses[busId];
     if(bus->bus_type != 0x01){
-        writeSerial("ERROR: Bus " + String(busId) + " is not an I2C bus", true);
+        od_log_error("ERROR: Bus %u is not an I2C bus", busId);
         return;
     }
     if(!initOrRestoreWireForBus(busId)){
-        writeSerial("ERROR: Failed to (re)init I2C bus " + String(busId) + " for AXP2101", true);
+        od_log_error("ERROR: Failed to (re)init I2C bus %u for AXP2101", busId);
         return;
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     uint8_t error = Wire.endTransmission();
     if(error != 0){
-        writeSerial("ERROR: AXP2101 not found at address 0x" + String(AXP2101_SLAVE_ADDRESS, HEX) + " (error: " + String(error) + ")", true);
+        od_log_error("ERROR: AXP2101 not found at address 0x%02X (error: %u)", AXP2101_SLAVE_ADDRESS, error);
         return;
     }
-    writeSerial("AXP2101 detected at address 0x" + String(AXP2101_SLAVE_ADDRESS, HEX), true);
+    od_log_debug("AXP2101 detected at address 0x%02X", AXP2101_SLAVE_ADDRESS);
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     Wire.write(AXP2101_REG_POWER_STATUS);
     error = Wire.endTransmission();
@@ -1070,7 +1075,7 @@ void initAXP2101(uint8_t busId){
         Wire.requestFrom(AXP2101_SLAVE_ADDRESS, (uint8_t)1);
         if(Wire.available()){
             uint8_t status = Wire.read();
-            writeSerial("Power status: 0x" + String(status, HEX), true);
+            od_log_debug("Power status: 0x%02X", status);
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1078,9 +1083,9 @@ void initAXP2101(uint8_t busId){
     Wire.write(0x12);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("DCDC1 voltage set to 3.3V", true);
+        od_log_debug("DCDC1 voltage set to 3.3V");
     } else {
-        writeSerial("ERROR: Failed to set DCDC1 voltage", true);
+        od_log_error("ERROR: Failed to set DCDC1 voltage");
     }
     delay(10);
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1099,9 +1104,9 @@ void initAXP2101(uint8_t busId){
     Wire.write(dcEnable);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("DCDC1 enabled (3.3V)", true);
+        od_log_debug("DCDC1 enabled (3.3V)");
     } else {
-        writeSerial("ERROR: Failed to enable DCDC1", true);
+        od_log_error("ERROR: Failed to enable DCDC1");
     }
     delay(10);
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1130,7 +1135,7 @@ void initAXP2101(uint8_t busId){
     Wire.write(aldo3VolReg);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("ALDO3 voltage set to 3.3V", true);
+        od_log_debug("ALDO3 voltage set to 3.3V");
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     Wire.write(AXP2101_REG_LDO_VOL3_CTRL);
@@ -1148,7 +1153,7 @@ void initAXP2101(uint8_t busId){
     Wire.write(aldo4VolReg);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("ALDO4 voltage set to 3.3V", true);
+        od_log_debug("ALDO4 voltage set to 3.3V");
     }
     aldoEnable |= 0x0C;
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1156,7 +1161,7 @@ void initAXP2101(uint8_t busId){
     Wire.write(aldoEnable);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("ALDO3 and ALDO4 enabled (3.3V)", true);
+        od_log_debug("ALDO3 and ALDO4 enabled (3.3V)");
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     Wire.write(AXP2101_REG_POWER_WAKEUP_CTL);
@@ -1165,29 +1170,29 @@ void initAXP2101(uint8_t busId){
         Wire.requestFrom(AXP2101_SLAVE_ADDRESS, (uint8_t)1);
         if(Wire.available()){
             uint8_t wakeupCtl = Wire.read();
-            writeSerial("Wakeup control: 0x" + String(wakeupCtl, HEX), true);
+            od_log_debug("Wakeup control: 0x%02X", wakeupCtl);
             if(wakeupCtl & 0x01){
-                writeSerial("Wakeup already enabled", true);
+                od_log_debug("Wakeup already enabled");
             } else {
                 Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
                 Wire.write(AXP2101_REG_POWER_WAKEUP_CTL);
                 Wire.write(wakeupCtl | 0x01);
                 error = Wire.endTransmission();
                 if(error == 0){
-                    writeSerial("Wakeup enabled", true);
+                    od_log_debug("Wakeup enabled");
                 }
             }
         }
     }
-    writeSerial("=== AXP2101 PMIC Initialization Complete ===", true);
+    od_log_info("=== AXP2101 PMIC Initialization Complete ===");
 }
 
 void readAXP2101Data(){
-    writeSerial("=== Reading AXP2101 PMIC Data ===", true);
+    od_log_info("=== Reading AXP2101 PMIC Data ===");
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     uint8_t error = Wire.endTransmission();
     if(error != 0){
-        writeSerial("ERROR: AXP2101 not found at address 0x" + String(AXP2101_SLAVE_ADDRESS, HEX), true);
+        od_log_error("ERROR: AXP2101 not found at address 0x%02X", AXP2101_SLAVE_ADDRESS);
         return;
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1203,14 +1208,14 @@ void readAXP2101Data(){
         if(Wire.available() >= 2){
             uint8_t status1 = Wire.read();
             uint8_t status2 = Wire.read();
-            writeSerial("Power Status 1: 0x" + String(status1, HEX), true);
-            writeSerial("Power Status 2: 0x" + String(status2, HEX), true);
+            od_log_debug("Power Status 1: 0x%02X", status1);
+            od_log_debug("Power Status 2: 0x%02X", status2);
             bool batteryPresent = (status1 & 0x20) != 0;
             bool charging = (status1 & 0x04) != 0;
             bool vbusPresent = (status1 & 0x08) != 0;
-            writeSerial("Battery Present: " + String(batteryPresent ? "Yes" : "No"), true);
-            writeSerial("Charging: " + String(charging ? "Yes" : "No"), true);
-            writeSerial("VBUS Present: " + String(vbusPresent ? "Yes" : "No"), true);
+            od_log_debug("Battery Present: %s", batteryPresent ? "Yes" : "No");
+            od_log_debug("Charging: %s", charging ? "Yes" : "No");
+            od_log_debug("VBUS Present: %s", vbusPresent ? "Yes" : "No");
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1220,7 +1225,7 @@ void readAXP2101Data(){
         Wire.requestFrom(AXP2101_SLAVE_ADDRESS, (uint8_t)1);
         if(Wire.available()){
             uint8_t pwronStatus = Wire.read();
-            writeSerial("Power On Status: 0x" + String(pwronStatus, HEX), true);
+            od_log_debug("Power On Status: 0x%02X", pwronStatus);
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1233,7 +1238,7 @@ void readAXP2101Data(){
             uint8_t batVolL = Wire.read();
             uint16_t batVolRaw = ((uint16_t)batVolH << 4) | (batVolL & 0x0F);
             float batVoltage = batVolRaw * 0.5;
-            writeSerial("Battery Voltage: " + String(batVoltage, 1) + " mV (" + String(batVoltage / 1000.0, 2) + " V)", true);
+            od_log_debug("Battery Voltage: %.1f mV (%.2f V)", batVoltage, batVoltage / 1000.0);
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1246,7 +1251,7 @@ void readAXP2101Data(){
             uint8_t vbusVolL = Wire.read();
             uint16_t vbusVolRaw = ((uint16_t)vbusVolH << 4) | (vbusVolL & 0x0F);
             float vbusVoltage = vbusVolRaw * 1.7;
-            writeSerial("VBUS Voltage: " + String(vbusVoltage, 1) + " mV (" + String(vbusVoltage / 1000.0, 2) + " V)", true);
+            od_log_debug("VBUS Voltage: %.1f mV (%.2f V)", vbusVoltage, vbusVoltage / 1000.0);
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1259,7 +1264,7 @@ void readAXP2101Data(){
             uint8_t sysVolL = Wire.read();
             uint16_t sysVolRaw = ((uint16_t)sysVolH << 4) | (sysVolL & 0x0F);
             float sysVoltage = sysVolRaw * 1.4;
-            writeSerial("System Voltage: " + String(sysVoltage, 1) + " mV (" + String(sysVoltage / 1000.0, 2) + " V)", true);
+            od_log_debug("System Voltage: %.1f mV (%.2f V)", sysVoltage, sysVoltage / 1000.0);
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1270,9 +1275,9 @@ void readAXP2101Data(){
         if(Wire.available()){
             uint8_t batPercent = Wire.read();
             if(batPercent <= 100){
-                writeSerial("Battery Percentage: " + String(batPercent) + "%", true);
+                od_log_debug("Battery Percentage: %u%%", batPercent);
             } else {
-                writeSerial("Battery Percentage: Not available (fuel gauge may be disabled)", true);
+                od_log_debug("Battery Percentage: Not available (fuel gauge may be disabled)");
             }
         }
     }
@@ -1283,12 +1288,12 @@ void readAXP2101Data(){
         Wire.requestFrom(AXP2101_SLAVE_ADDRESS, (uint8_t)1);
         if(Wire.available()){
             uint8_t dcEnable = Wire.read();
-            writeSerial("DC Enable Status: 0x" + String(dcEnable, HEX), true);
-            writeSerial("  DCDC1: " + String((dcEnable & 0x01) ? "ON" : "OFF"), true);
-            writeSerial("  DCDC2: " + String((dcEnable & 0x02) ? "ON" : "OFF"), true);
-            writeSerial("  DCDC3: " + String((dcEnable & 0x04) ? "ON" : "OFF"), true);
-            writeSerial("  DCDC4: " + String((dcEnable & 0x08) ? "ON" : "OFF"), true);
-            writeSerial("  DCDC5: " + String((dcEnable & 0x10) ? "ON" : "OFF"), true);
+            od_log_debug("DC Enable Status: 0x%02X", dcEnable);
+            od_log_debug("  DCDC1: %s", (dcEnable & 0x01) ? "ON" : "OFF");
+            od_log_debug("  DCDC2: %s", (dcEnable & 0x02) ? "ON" : "OFF");
+            od_log_debug("  DCDC3: %s", (dcEnable & 0x04) ? "ON" : "OFF");
+            od_log_debug("  DCDC4: %s", (dcEnable & 0x08) ? "ON" : "OFF");
+            od_log_debug("  DCDC5: %s", (dcEnable & 0x10) ? "ON" : "OFF");
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1298,22 +1303,22 @@ void readAXP2101Data(){
         Wire.requestFrom(AXP2101_SLAVE_ADDRESS, (uint8_t)1);
         if(Wire.available()){
             uint8_t aldoEnable = Wire.read();
-            writeSerial("ALDO Enable Status: 0x" + String(aldoEnable, HEX), true);
-            writeSerial("  ALDO1: " + String((aldoEnable & 0x01) ? "ON" : "OFF"), true);
-            writeSerial("  ALDO2: " + String((aldoEnable & 0x02) ? "ON" : "OFF"), true);
-            writeSerial("  ALDO3: " + String((aldoEnable & 0x04) ? "ON" : "OFF"), true);
-            writeSerial("  ALDO4: " + String((aldoEnable & 0x08) ? "ON" : "OFF"), true);
+            od_log_debug("ALDO Enable Status: 0x%02X", aldoEnable);
+            od_log_debug("  ALDO1: %s", (aldoEnable & 0x01) ? "ON" : "OFF");
+            od_log_debug("  ALDO2: %s", (aldoEnable & 0x02) ? "ON" : "OFF");
+            od_log_debug("  ALDO3: %s", (aldoEnable & 0x04) ? "ON" : "OFF");
+            od_log_debug("  ALDO4: %s", (aldoEnable & 0x08) ? "ON" : "OFF");
         }
     }
-    writeSerial("=== AXP2101 Data Read Complete ===", true);
+    od_log_info("=== AXP2101 Data Read Complete ===");
 }
 
 void powerDownAXP2101(){
-    writeSerial("=== Powering Down AXP2101 PMIC Rails ===", true);
+    od_log_info("=== Powering Down AXP2101 PMIC Rails ===");
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     uint8_t error = Wire.endTransmission();
     if(error != 0){
-        writeSerial("ERROR: AXP2101 not found at address 0x" + String(AXP2101_SLAVE_ADDRESS, HEX) + " (error: " + String(error) + ")", true);
+        od_log_error("ERROR: AXP2101 not found at address 0x%02X (error: %u)", AXP2101_SLAVE_ADDRESS, error);
         return;
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1362,7 +1367,7 @@ void powerDownAXP2101(){
         Wire.write(0xFF);
         error = Wire.endTransmission();
         if(error == 0){
-            writeSerial("All IRQs disabled and status cleared", true);
+            od_log_debug("All IRQs disabled and status cleared");
         }
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
@@ -1381,18 +1386,18 @@ void powerDownAXP2101(){
     Wire.write(dcEnable);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("DC2-5 disabled (DC1 kept enabled)", true);
+        od_log_debug("DC2-5 disabled (DC1 kept enabled)");
     } else {
-        writeSerial("ERROR: Failed to disable DC2-5", true);
+        od_log_error("ERROR: Failed to disable DC2-5");
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     Wire.write(AXP2101_REG_LDO_ONOFF_CTRL1);
     Wire.write(0x00);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("BLDO1-2, CPUSLDO, DLDO1-2 disabled", true);
+        od_log_debug("BLDO1-2, CPUSLDO, DLDO1-2 disabled");
     } else {
-        writeSerial("ERROR: Failed to disable BLDO/CPUSLDO/DLDO rails", true);
+        od_log_error("ERROR: Failed to disable BLDO/CPUSLDO/DLDO rails");
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     Wire.write(AXP2101_REG_LDO_ONOFF_CTRL0);
@@ -1410,9 +1415,9 @@ void powerDownAXP2101(){
     Wire.write(aldoEnable);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("ALDO1-4 disabled", true);
+        od_log_debug("ALDO1-4 disabled");
     } else {
-        writeSerial("ERROR: Failed to disable ALDO rails", true);
+        od_log_error("ERROR: Failed to disable ALDO rails");
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     Wire.write(AXP2101_REG_POWER_WAKEUP_CTL);
@@ -1439,20 +1444,20 @@ void powerDownAXP2101(){
     Wire.write(wakeupCtrl);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("AXP2101 wake-up configured and sleep mode enabled", true);
+        od_log_debug("AXP2101 wake-up configured and sleep mode enabled");
     } else {
-        writeSerial("ERROR: Failed to configure AXP2101 sleep mode", true);
+        od_log_error("ERROR: Failed to configure AXP2101 sleep mode");
     }
     Wire.beginTransmission(AXP2101_SLAVE_ADDRESS);
     Wire.write(AXP2101_REG_ADC_CHANNEL_CTRL);
     Wire.write(0x00);
     error = Wire.endTransmission();
     if(error == 0){
-        writeSerial("All ADC channels disabled", true);
+        od_log_debug("All ADC channels disabled");
     } else {
-        writeSerial("ERROR: Failed to disable ADC channels", true);
+        od_log_error("ERROR: Failed to disable ADC channels");
     }
-    writeSerial("=== AXP2101 PMIC Rails Powered Down ===", true);
+    od_log_info("=== AXP2101 PMIC Rails Powered Down ===");
 }
 
 static void renderChar_4BPP(uint8_t* rowBuffer, const uint8_t* fontData, int fontRow, int charIdx, int startX, int charWidth, int pitch, int fontScale) {
@@ -1531,26 +1536,28 @@ static void renderChar_1BPP(uint8_t* rowBuffer, const uint8_t* fontData, int fon
 }
 
 void initDisplay(){
-    writeSerial("=== Initializing Display ===", true);
+    od_log_info("=== Initializing Display ===");
     if(globalConfig.display_count > 0){
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_FASTEPD)
     if (fastepd_driver_used()) {
         pwrmgm(true);
-        writeSerial("Display: FastEPD IT8951 (panel_ic " + String(globalConfig.displays[0].panel_ic_type) + ", " +
-                    String(globalConfig.displays[0].pixel_width) + "x" + String(globalConfig.displays[0].pixel_height) + ", " +
-                    String(getBitsPerPixel()) + " bpp)", true);
+        int bitsPerPixel = getBitsPerPixel();
+        od_log_info("Display: FastEPD IT8951 (panel_ic %u, %ux%u, %d bpp)",
+                    globalConfig.displays[0].panel_ic_type,
+                    globalConfig.displays[0].pixel_width, globalConfig.displays[0].pixel_height,
+                    bitsPerPixel);
         fastepd_epaper_begin();
         if (fastepd_init_failed()) {
-            writeSerial("FastEPD init failed — skipping boot refresh", true);
+            od_log_warn("FastEPD init failed — skipping boot refresh");
             fastepd_mark_hw_deinitialized();
             pwrmgm(false);
             return;
         }
-        writeSerial(String("Height: ") + String(globalConfig.displays[0].pixel_height), true);
-        writeSerial(String("Width: ") + String(globalConfig.displays[0].pixel_width), true);
+        od_log_info("Height: %u", globalConfig.displays[0].pixel_height);
+        od_log_info("Width: %u", globalConfig.displays[0].pixel_width);
         if (! (globalConfig.displays[0].transmission_modes & OD_TRANSMISSION_MODE_CLEAR_ON_BOOT)){
             writeBootScreenWithQr();
-            writeSerial("EPD refresh: FULL (boot, FastEPD)", true);
+            od_log_info("EPD refresh: FULL (boot, FastEPD)");
             touchSuspendForEpdRefresh();
             fastepd_full_update();
             waitforrefresh(60);
@@ -1574,20 +1581,20 @@ void initDisplay(){
             if (globalConfig.displays[0].pixel_width != bbep.native_width ||
                 globalConfig.displays[0].pixel_height != bbep.native_height ||
                 globalConfig.displays[0].color_scheme != OD_COLOR_SCHEME_BWGBRY_SPLIT) {
-                writeSerial("ERROR: E1004 requires a 1200x1600 bwgbry_split (8) display config", true);
+                od_log_error("ERROR: E1004 requires a 1200x1600 bwgbry_split (8) display config");
             } else {
                 e1004GeometryOk = true;
             }
         }
 #endif
         bbepSetRotation(&bbep, rotation);
-        writeSerial(String("Height: ") + String(globalConfig.displays[0].pixel_height), true);
-        writeSerial(String("Width: ") + String(globalConfig.displays[0].pixel_width), true);
+        od_log_info("Height: %u", globalConfig.displays[0].pixel_height);
+        od_log_info("Width: %u", globalConfig.displays[0].pixel_width);
         initBbepPanelSession();
         if (! (globalConfig.displays[0].transmission_modes & OD_TRANSMISSION_MODE_CLEAR_ON_BOOT)){
             bool bootOk = refreshBootScreenFull();
             if (!bootOk && !nrfVbusPresent()) {
-                writeSerial("Boot refresh failed on battery — re-powering panel and retrying", true);
+                od_log_warn("Boot refresh failed on battery — re-powering panel and retrying");
                 touchResumeAfterEpdRefresh();
                 pwrmgm(false);
                 delay(200);
@@ -1596,7 +1603,7 @@ void initDisplay(){
                 bootOk = refreshBootScreenFull();
             }
             if (!bootOk) {
-                writeSerial("Boot screen refresh did not complete", true);
+                od_log_warn("Boot screen refresh did not complete");
             }
             // Boot ends PWR_OFF (no keep-alive at boot). pwrmgm(true) in boot set
             // PWR_ACTIVE, so ForceOff sleeps the controller + cuts the rail cleanly.
@@ -1610,7 +1617,7 @@ void initDisplay(){
     }
     }
     else{
-        writeSerial("No display found", true);
+        od_log_warn("No display found");
     }
 }
 
@@ -1797,14 +1804,17 @@ static uint8_t  imgLogLastHead[16];  // first bytes of most recent frame
 static uint8_t  imgLogLastHeadLen;   // valid bytes in imgLogLastHead
 static uint32_t imgLogStartMs;       // millis() at stream start (for throughput)
 
-static String imgLogHex(const uint8_t* buf, uint8_t n) {
-    String s;
-    for (uint8_t i = 0; i < n; i++) {
-        if (i > 0) s += " ";
-        if (buf[i] < 16) s += "0";
-        s += String(buf[i], HEX);
+// Builds a space-separated "%02X" hex dump of up to sizeof(imgLogLastHead) bytes into buf.
+static void imgLogHex(char* buf, size_t bufSize, const uint8_t* data, uint8_t n) {
+    int pos = 0;
+    buf[0] = '\0';
+    for (uint8_t i = 0; i < n && pos < (int)bufSize; i++) {
+        int written = snprintf(buf + pos, bufSize - pos, i > 0 ? " %02X" : "%02X", data[i]);
+        if (written < 0) {
+            break;
+        }
+        pos += written;
     }
-    return s;
 }
 
 static void imageWriteLogReset(void) {
@@ -1819,7 +1829,7 @@ static void imageWriteLogReset(void) {
 static void imageWriteLogStart(uint32_t totalBytes) {
     imgLogTotalBytes = totalBytes;
     imgLogStartMs = millis();
-    writeSerial("DW start: " + String(totalBytes) + " bytes expected", true);
+    od_log_debug("DW start: %u bytes expected", (unsigned)totalBytes);
 }
 
 static void imageWriteLogChunk(const uint8_t* data, uint16_t len) {
@@ -1828,10 +1838,12 @@ static void imageWriteLogChunk(const uint8_t* data, uint16_t len) {
     imgLogLastHeadLen = (len < sizeof(imgLogLastHead)) ? (uint8_t)len : (uint8_t)sizeof(imgLogLastHead);
     memcpy(imgLogLastHead, data, imgLogLastHeadLen);
     if (imgLogChunks == 1) {
-        writeSerial("DW frame 1: " + String(len) + " bytes: " + imgLogHex(imgLogLastHead, imgLogLastHeadLen), true);
+        char hex[64];
+        imgLogHex(hex, sizeof(hex), imgLogLastHead, imgLogLastHeadLen);
+        od_log_debug("DW frame 1: %u bytes: %s", len, hex);
         if (len > 0 && imgLogTotalBytes > 0) {
             uint32_t est = (imgLogTotalBytes + len - 1) / len;
-            writeSerial("DW expecting ~" + String(est) + " chunks", true);
+            od_log_debug("DW expecting ~%u chunks", (unsigned)est);
         }
     }
 }
@@ -1843,19 +1855,22 @@ static void imageWriteLogProgress(uint32_t written, uint32_t total) {
     uint8_t step = (uint8_t)(pct / 5u);
     if (step <= imgLogLastStep) return;
     imgLogLastStep = step;
-    writeSerial("DW " + String(pct) + "% (" + String(imgLogChunks) + " chunks, " +
-                String(written) + "/" + String(total) + " bytes)", true);
+    od_log_debug("DW %u%% (%u chunks, %u/%u bytes)", (unsigned)pct, (unsigned)imgLogChunks, (unsigned)written, (unsigned)total);
 }
 
 static void imageWriteLogFinish(uint32_t written, uint32_t total) {
-    writeSerial("DW final frame " + String(imgLogChunks) + ": " + String(imgLogLastLen) +
-                " bytes: " + imgLogHex(imgLogLastHead, imgLogLastHeadLen), true);
+    char hex[64];
+    imgLogHex(hex, sizeof(hex), imgLogLastHead, imgLogLastHeadLen);
+    od_log_debug("DW final frame %u: %u bytes: %s", (unsigned)imgLogChunks, imgLogLastLen, hex);
     uint32_t elapsedMs = millis() - imgLogStartMs;   // unsigned wrap-safe over one stream
-    String rate = "n/a";
-    if (elapsedMs > 0) rate = String((float)written / 1.024f / (float)elapsedMs, 1);  // bytes/ms /1.024 = KB/s
-    writeSerial("DW complete: " + String(imgLogChunks) + " chunks, " +
-                String(written) + "/" + String(total) + " bytes, " +
-                String(elapsedMs / 1000.0f, 2) + " s, " + rate + " KB/s", true);
+    if (elapsedMs > 0) {
+        float rate = (float)written / 1.024f / (float)elapsedMs;  // bytes/ms /1.024 = KB/s
+        od_log_debug("DW complete: %u chunks, %u/%u bytes, %.2f s, %.1f KB/s",
+                    (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, elapsedMs / 1000.0f, rate);
+    } else {
+        od_log_debug("DW complete: %u chunks, %u/%u bytes, %.2f s, n/a KB/s",
+                    (unsigned)imgLogChunks, (unsigned)written, (unsigned)total, elapsedMs / 1000.0f);
+    }
 }
 
 bool imageWriteLogQuietCmd(void) {
@@ -2026,7 +2041,7 @@ static void directWriteActivatePanel(void) {
 #ifdef BBEP_T133A01
     if (e1004_panel_used()) {
         if (!e1004_begin_plane()) {
-            writeSerial("ERROR: E1004 dual-CS plane open failed", true);
+            od_log_error("ERROR: E1004 dual-CS plane open failed");
         }
     } else
 #endif
@@ -2304,18 +2319,12 @@ static void directWriteFinishAndRefresh(uint8_t* data, uint16_t len, uint8_t end
     int refreshMode = REFRESH_FULL;
     if (data != nullptr && len >= 1 && data[0] == 1) refreshMode = REFRESH_FAST;
     if (e1004_panel_used()) refreshMode = REFRESH_FULL;  // fast re-init would wipe RAM
-    writeSerial("EPD refresh: ", false);
-    writeSerial(refreshMode == REFRESH_FAST ? "FAST" : "FULL", false);
-    writeSerial(" (mode=", false);
-    writeSerial(String(refreshMode), false);
-    writeSerial(", end payload ", false);
+    const char* modeName = (refreshMode == REFRESH_FAST) ? "FAST" : "FULL";
     if (data != nullptr && len > 0) {
-        writeSerial("0x", false);
-        writeSerial(String(data[0], HEX), false);
+        od_log_info("EPD refresh: %s (mode=%d, end payload 0x%02X)", modeName, refreshMode, data[0]);
     } else {
-        writeSerial("none (auto)", false);
+        od_log_info("EPD refresh: %s (mode=%d, end payload none (auto))", modeName, refreshMode);
     }
-    writeSerial(")", true);
     uint8_t ackResponse[] = {0x00, endOpcode};
     sendResponse(ackResponse, sizeof(ackResponse));
     delay(20);
@@ -3019,7 +3028,8 @@ static bool partial_consume_bytes(uint8_t* data, uint32_t len) {
 static bool zlib_stream_to_direct_write(const uint8_t* data, uint32_t len, bool final) {
     od_zlib_status_t status = od_zlib_stream_push(data, len, final);
     if (status == OD_ZLIB_STATUS_ERROR) {
-        writeSerial(String("zlib stream error: ") + od_zlib_stream_error(), true);
+        const char* zlibErr = od_zlib_stream_error();
+        od_log_error("zlib stream error: %s", zlibErr);
         return false;
     }
 
@@ -3055,7 +3065,8 @@ static bool zlib_stream_to_direct_write(const uint8_t* data, uint32_t len, bool 
             }
             return true;
         }
-        writeSerial(String("zlib stream error: ") + od_zlib_stream_error(), true);
+        const char* zlibErr = od_zlib_stream_error();
+        od_log_error("zlib stream error: %s", zlibErr);
         return false;
     }
 }
@@ -3063,7 +3074,8 @@ static bool zlib_stream_to_direct_write(const uint8_t* data, uint32_t len, bool 
 static bool zlib_stream_to_partial_write(const uint8_t* data, uint32_t len, bool final) {
     od_zlib_status_t status = od_zlib_stream_push(data, len, final);
     if (status == OD_ZLIB_STATUS_ERROR) {
-        writeSerial(String("partial zlib stream error: ") + od_zlib_stream_error(), true);
+        const char* zlibErr = od_zlib_stream_error();
+        od_log_error("partial zlib stream error: %s", zlibErr);
         return false;
     }
 
@@ -3074,7 +3086,8 @@ static bool zlib_stream_to_partial_write(const uint8_t* data, uint32_t len, bool
         if (status == OD_ZLIB_STATUS_OUTPUT_READY) continue;
         if (status == OD_ZLIB_STATUS_NEEDS_INPUT) return !final;
         if (status == OD_ZLIB_STATUS_DONE) return partialCtx.bytes_written == partialCtx.expected_stream_size;
-        writeSerial(String("partial zlib stream error: ") + od_zlib_stream_error(), true);
+        const char* zlibErr = od_zlib_stream_error();
+        od_log_error("partial zlib stream error: %s", zlibErr);
         return false;
     }
 }
@@ -3133,16 +3146,15 @@ static bool partial_trigger_refresh(int refreshMode) {
 static void partial_prepare_panel_ram(void) {
     // Delta in ms since function entry, to profile where prep wall-clock goes.
     uint32_t t0 = millis();
-    writeSerial("[+" + String(millis() - t0) + "ms] EPD partial start: acquire panel session", true);
+    od_log_debug("[+%ums] EPD partial start: acquire panel session", (unsigned)(millis() - t0));
     // Acquire subsumes pwrmgm(true) + bbepInitIO + bbepWakeUp + init-seq resend.
     // Warm re-acquire skips the ~900 ms rail bring-up + bbepInitIO (Phase 1).
     bool cold = epdSessionAcquire(true);
-    writeSerial("[+" + String(millis() - t0) + "ms] after epdSessionAcquire (" +
-                String(cold ? "cold" : "warm") + ")", true);
+    od_log_debug("[+%ums] after epdSessionAcquire (%s)", (unsigned)(millis() - t0), cold ? "cold" : "warm");
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_FASTEPD)
     if (fastepd_driver_used()) {
         fastepd_partial_prepare(partialCtx.x, partialCtx.y, partialCtx.width, partialCtx.height);
-        writeSerial("[+" + String(millis() - t0) + "ms] FastEPD partial prepare done", true);
+        od_log_debug("[+%ums] FastEPD partial prepare done", (unsigned)(millis() - t0));
         return;
     }
 #endif
@@ -3157,22 +3169,15 @@ static void partial_prepare_panel_ram(void) {
     if (!fullFrame) {
         bbepFill(&bbep, BBEP_WHITE, PLANE_1);
         bbepFill(&bbep, BBEP_WHITE, PLANE_0);
-        writeSerial("[+" + String(millis() - t0) + "ms] after fills (ran: sub-rect)", true);
+        od_log_debug("[+%ums] after fills (ran: sub-rect)", (unsigned)(millis() - t0));
     } else {
-        writeSerial("[+" + String(millis() - t0) + "ms] fills skipped (full-frame rect)", true);
+        od_log_debug("[+%ums] fills skipped (full-frame rect)", (unsigned)(millis() - t0));
     }
 }
 
 static bool partial_write_to_panel(int refreshMode) {
-    writeSerial("EPD refresh: PARTIAL (raw rect ", false);
-    writeSerial(String(partialCtx.x), false);
-    writeSerial(",", false);
-    writeSerial(String(partialCtx.y), false);
-    writeSerial(" ", false);
-    writeSerial(String(partialCtx.width), false);
-    writeSerial("x", false);
-    writeSerial(String(partialCtx.height), false);
-    writeSerial(")", true);
+    od_log_info("EPD refresh: PARTIAL (raw rect %u,%u %ux%u)",
+                partialCtx.x, partialCtx.y, partialCtx.width, partialCtx.height);
 
     if (partialCtx.bytes_written != partialCtx.expected_stream_size) return false;
     epdRefreshInProgress = true;

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -41,6 +41,10 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
 bool constantTimeCompare(const uint8_t* a, const uint8_t* b, size_t len);
 void secure_random(uint8_t* output, size_t len);
 void writeSerial(String message, bool newLine = true);
+#ifdef TARGET_ESP32
+static void ccm_session_init(EncryptionSession& session);
+static void ccm_session_free(EncryptionSession& session);
+#endif
 
 void getAuthDeviceIdBytes(uint8_t* device_id) {
     if (device_id == nullptr) return;

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -1,5 +1,6 @@
 #include "encryption.h"
 #include "encryption_state.h"
+#include "od_log.h"
 
 #ifdef TARGET_NRF
 #include <Arduino.h>
@@ -40,7 +41,6 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
                      uint8_t* plaintext, const uint8_t* tag, size_t tag_len);
 bool constantTimeCompare(const uint8_t* a, const uint8_t* b, size_t len);
 void secure_random(uint8_t* output, size_t len);
-void writeSerial(String message, bool newLine = true);
 #ifdef TARGET_ESP32
 static void ccm_session_init(EncryptionSession& session);
 static void ccm_session_free(EncryptionSession& session);
@@ -120,21 +120,17 @@ bool verifyNonceReplay(uint8_t* nonce) {
         nonce_counter = (nonce_counter << 8) | nonce[8 + i];
     }
     if (!constantTimeCompare(nonce_session_id, encryptionSession.session_id, 8)) {
-        char buf[256];
-        snprintf(buf, sizeof(buf), "ERROR: Nonce session_id mismatch\n  Nonce ID: %02X%02X%02X%02X%02X%02X%02X%02X\n  Expected: %02X%02X%02X%02X%02X%02X%02X%02X",
-                 nonce_session_id[0], nonce_session_id[1], nonce_session_id[2], nonce_session_id[3],
-                 nonce_session_id[4], nonce_session_id[5], nonce_session_id[6], nonce_session_id[7],
-                 encryptionSession.session_id[0], encryptionSession.session_id[1], encryptionSession.session_id[2], encryptionSession.session_id[3],
-                 encryptionSession.session_id[4], encryptionSession.session_id[5], encryptionSession.session_id[6], encryptionSession.session_id[7]);
-        writeSerial(buf, true);
+        od_log_error("ERROR: Nonce session_id mismatch\n  Nonce ID: %02X%02X%02X%02X%02X%02X%02X%02X\n  Expected: %02X%02X%02X%02X%02X%02X%02X%02X",
+                     nonce_session_id[0], nonce_session_id[1], nonce_session_id[2], nonce_session_id[3],
+                     nonce_session_id[4], nonce_session_id[5], nonce_session_id[6], nonce_session_id[7],
+                     encryptionSession.session_id[0], encryptionSession.session_id[1], encryptionSession.session_id[2], encryptionSession.session_id[3],
+                     encryptionSession.session_id[4], encryptionSession.session_id[5], encryptionSession.session_id[6], encryptionSession.session_id[7]);
         return false;
     }
     int64_t counter_diff = (int64_t)nonce_counter - (int64_t)encryptionSession.last_seen_counter;
     if (counter_diff < -32 || counter_diff > 32) {
-        char buf[128];
-        snprintf(buf, sizeof(buf), "ERROR: Nonce counter outside replay window (counter=%llu, last_seen=%llu, diff=%lld)",
-                 (unsigned long long)nonce_counter, (unsigned long long)encryptionSession.last_seen_counter, (long long)counter_diff);
-        writeSerial(buf, true);
+        od_log_error("ERROR: Nonce counter outside replay window (counter=%llu, last_seen=%llu, diff=%lld)",
+                     (unsigned long long)nonce_counter, (unsigned long long)encryptionSession.last_seen_counter, (long long)counter_diff);
         return false;
     }
     if (nonce_counter <= encryptionSession.last_seen_counter && counter_diff != 0) {
@@ -146,7 +142,7 @@ bool verifyNonceReplay(uint8_t* nonce) {
             }
         }
         if (already_seen) {
-            writeSerial("ERROR: Nonce counter already seen (replay detected)", true);
+            od_log_error("ERROR: Nonce counter already seen (replay detected)");
             return false;
         }
     }
@@ -206,7 +202,7 @@ void clearEncryptionSession() {
     encryptionSession.auth_attempts = 0;
     encryptionSession.server_nonce_time = 0;
     memset(encryptionSession.replay_window, 0, sizeof(encryptionSession.replay_window));
-    writeSerial("Encryption session cleared");
+    od_log_info("Encryption session cleared");
 }
 
 bool checkEncryptionSessionTimeout() {
@@ -215,8 +211,7 @@ bool checkEncryptionSessionTimeout() {
     uint32_t currentTime = millis() / 1000;
     uint32_t sessionAge = currentTime - (encryptionSession.session_start_time / 1000);
     if (sessionAge >= securityConfig.session_timeout_seconds) {
-        writeSerial("Encryption session timeout (" + String(sessionAge) + "s >= " +
-                   String(securityConfig.session_timeout_seconds) + "s)");
+        od_log_info("Encryption session timeout (%us >= %us)", (unsigned)sessionAge, securityConfig.session_timeout_seconds);
         clearEncryptionSession();
         return false;
     }
@@ -249,7 +244,7 @@ static void ccm_session_init(EncryptionSession& session) {
     } else {
         mbedtls_ccm_free(&session.ccm_ctx);
         session.is_ccm_ready = false;
-        writeSerial("ERROR: Failed to initialize CCM session context");
+        od_log_error("ERROR: Failed to initialize CCM session context");
     }
 }
 
@@ -264,27 +259,27 @@ bool aes_cmac(const uint8_t* key, const uint8_t* message, size_t message_len, ui
     mbedtls_cipher_context_t ctx;
     const mbedtls_cipher_info_t* cipher_info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
     if (cipher_info == NULL) {
-        writeSerial("ERROR: Failed to get cipher info for AES-128-ECB");
+        od_log_error("ERROR: Failed to get cipher info for AES-128-ECB");
         return false;
     }
     mbedtls_cipher_init(&ctx);
     if (mbedtls_cipher_setup(&ctx, cipher_info) != 0) {
-        writeSerial("ERROR: Failed to setup cipher");
+        od_log_error("ERROR: Failed to setup cipher");
         mbedtls_cipher_free(&ctx);
         return false;
     }
     if (mbedtls_cipher_cmac_starts(&ctx, key, 128) != 0) {
-        writeSerial("ERROR: Failed to start CMAC");
+        od_log_error("ERROR: Failed to start CMAC");
         mbedtls_cipher_free(&ctx);
         return false;
     }
     if (mbedtls_cipher_cmac_update(&ctx, message, message_len) != 0) {
-        writeSerial("ERROR: Failed to update CMAC");
+        od_log_error("ERROR: Failed to update CMAC");
         mbedtls_cipher_free(&ctx);
         return false;
     }
     if (mbedtls_cipher_cmac_finish(&ctx, mac) != 0) {
-        writeSerial("ERROR: Failed to finish CMAC");
+        od_log_error("ERROR: Failed to finish CMAC");
         mbedtls_cipher_free(&ctx);
         return false;
     }
@@ -296,12 +291,12 @@ bool aes_ecb_encrypt(const uint8_t* key, const uint8_t* input, uint8_t* output) 
     mbedtls_aes_context aes;
     mbedtls_aes_init(&aes);
     if (mbedtls_aes_setkey_enc(&aes, key, 128) != 0) {
-        writeSerial("ERROR: Failed to set AES key");
+        od_log_error("ERROR: Failed to set AES key");
         mbedtls_aes_free(&aes);
         return false;
     }
     if (mbedtls_aes_crypt_ecb(&aes, MBEDTLS_AES_ENCRYPT, input, output) != 0) {
-        writeSerial("ERROR: Failed to encrypt with AES-ECB");
+        od_log_error("ERROR: Failed to encrypt with AES-ECB");
         mbedtls_aes_free(&aes);
         return false;
     }
@@ -320,7 +315,7 @@ bool aes_ccm_encrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
     } else {
         mbedtls_ccm_init(&local_ctx);
         if (mbedtls_ccm_setkey(&local_ctx, MBEDTLS_CIPHER_ID_AES, key, 128) != 0) {
-            writeSerial("ERROR: Failed to set CCM key");
+            od_log_error("ERROR: Failed to set CCM key");
             mbedtls_ccm_free(&local_ctx);
             return false;
         }
@@ -332,7 +327,7 @@ bool aes_ccm_encrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
         mbedtls_ccm_free(&local_ctx);
     }
     if (ret != 0) {
-        writeSerial("ERROR: CCM encrypt failed: " + String((int)ret));
+        od_log_error("ERROR: CCM encrypt failed: %d", ret);
         return false;
     }
     return true;
@@ -343,15 +338,15 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
                      const uint8_t* ciphertext, size_t ciphertext_len,
                      uint8_t* plaintext, const uint8_t* tag, size_t tag_len) {
     if (nonce_len < 7 || nonce_len > 13) {
-        writeSerial("ERROR: Invalid CCM nonce length (must be 7-13 bytes)");
+        od_log_error("ERROR: Invalid CCM nonce length (must be 7-13 bytes)");
         return false;
     }
     if (tag_len != 4 && tag_len != 6 && tag_len != 8 && tag_len != 10 && tag_len != 12 && tag_len != 14 && tag_len != 16) {
-        writeSerial("ERROR: Invalid CCM tag length (must be 4, 6, 8, 10, 12, 14, or 16 bytes)");
+        od_log_error("ERROR: Invalid CCM tag length (must be 4, 6, 8, 10, 12, 14, or 16 bytes)");
         return false;
     }
     if (ciphertext_len == 0) {
-        writeSerial("ERROR: CCM ciphertext length is 0 (must be at least 1 byte)");
+        od_log_error("ERROR: CCM ciphertext length is 0 (must be at least 1 byte)");
         return false;
     }
     mbedtls_ccm_context *ctx = NULL;
@@ -361,7 +356,7 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
     } else {
         mbedtls_ccm_init(&local_ctx);
         if (mbedtls_ccm_setkey(&local_ctx, MBEDTLS_CIPHER_ID_AES, key, 128) != 0) {
-            writeSerial("ERROR: Failed to set CCM key");
+            od_log_error("ERROR: Failed to set CCM key");
             mbedtls_ccm_free(&local_ctx);
             return false;
         }
@@ -373,12 +368,10 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
         mbedtls_ccm_free(&local_ctx);
     }
     if (ret != 0) {
-        char err_buf[128];
-        snprintf(err_buf, sizeof(err_buf), "ERROR: CCM decrypt failed: %d (ciphertext_len=%zu, nonce_len=%zu, tag_len=%zu)",
-                 ret, ciphertext_len, nonce_len, tag_len);
-        writeSerial(err_buf);
+        od_log_error("ERROR: CCM decrypt failed: %d (ciphertext_len=%zu, nonce_len=%zu, tag_len=%zu)",
+                     ret, ciphertext_len, nonce_len, tag_len);
         if (ret == -15) {
-            writeSerial("ERROR: MBEDTLS_ERR_CCM_BAD_INPUT - invalid input parameters");
+            od_log_error("ERROR: MBEDTLS_ERR_CCM_BAD_INPUT - invalid input parameters");
         }
         return false;
     }
@@ -394,11 +387,11 @@ static bool cc310_initialized = false;
 static bool init_cc310() {
     if (cc310_initialized) return true;
     if (!nRFCrypto.begin()) {
-        writeSerial("ERROR: Failed to initialize CryptoCell CC310");
+        od_log_error("ERROR: Failed to initialize CryptoCell CC310");
         return false;
     }
     cc310_initialized = true;
-    writeSerial("CryptoCell CC310 initialized successfully");
+    od_log_info("CryptoCell CC310 initialized successfully");
     return true;
 }
 
@@ -410,12 +403,12 @@ bool aes_cmac(const uint8_t* key, const uint8_t* message, size_t message_len, ui
     keyData.keySize = 16;
     SaSiError_t err = SaSi_AesInit(&ctx, SASI_AES_ENCRYPT, SASI_AES_MODE_CMAC, SASI_AES_PADDING_NONE);
     if (err != SASI_OK) {
-        writeSerial("ERROR: SaSi_AesInit (CMAC) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: SaSi_AesInit (CMAC) failed: 0x%lX", (unsigned long)err);
         return false;
     }
     err = SaSi_AesSetKey(&ctx, SASI_AES_USER_KEY, &keyData, sizeof(keyData));
     if (err != SASI_OK) {
-        writeSerial("ERROR: SaSi_AesSetKey (CMAC) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: SaSi_AesSetKey (CMAC) failed: 0x%lX", (unsigned long)err);
         SaSi_AesFree(&ctx);
         return false;
     }
@@ -431,7 +424,7 @@ bool aes_cmac(const uint8_t* key, const uint8_t* message, size_t message_len, ui
     if (block_len > 0) {
         err = SaSi_AesBlock(&ctx, (uint8_t*)message, block_len, NULL);
         if (err != SASI_OK) {
-            writeSerial("ERROR: SaSi_AesBlock (CMAC) failed: 0x" + String((unsigned long)err, HEX));
+            od_log_error("ERROR: SaSi_AesBlock (CMAC) failed: 0x%lX", (unsigned long)err);
             SaSi_AesFree(&ctx);
             return false;
         }
@@ -439,7 +432,7 @@ bool aes_cmac(const uint8_t* key, const uint8_t* message, size_t message_len, ui
     size_t mac_size = 16;
     err = SaSi_AesFinish(&ctx, finish_len, (uint8_t*)message + finish_offset, finish_len, mac, &mac_size);
     if (err != SASI_OK) {
-        writeSerial("ERROR: SaSi_AesFinish (CMAC) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: SaSi_AesFinish (CMAC) failed: 0x%lX", (unsigned long)err);
         SaSi_AesFree(&ctx);
         return false;
     }
@@ -455,19 +448,19 @@ bool aes_ecb_encrypt(const uint8_t* key, const uint8_t* input, uint8_t* output) 
     keyData.keySize = 16;
     SaSiError_t err = SaSi_AesInit(&ctx, SASI_AES_ENCRYPT, SASI_AES_MODE_ECB, SASI_AES_PADDING_NONE);
     if (err != SASI_OK) {
-        writeSerial("ERROR: SaSi_AesInit (ECB) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: SaSi_AesInit (ECB) failed: 0x%lX", (unsigned long)err);
         return false;
     }
     err = SaSi_AesSetKey(&ctx, SASI_AES_USER_KEY, &keyData, sizeof(keyData));
     if (err != SASI_OK) {
-        writeSerial("ERROR: SaSi_AesSetKey (ECB) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: SaSi_AesSetKey (ECB) failed: 0x%lX", (unsigned long)err);
         SaSi_AesFree(&ctx);
         return false;
     }
     size_t out_size = 16;
     err = SaSi_AesFinish(&ctx, 16, (uint8_t*)input, 16, output, &out_size);
     if (err != SASI_OK) {
-        writeSerial("ERROR: SaSi_AesFinish (ECB) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: SaSi_AesFinish (ECB) failed: 0x%lX", (unsigned long)err);
         SaSi_AesFree(&ctx);
         return false;
     }
@@ -481,11 +474,11 @@ bool aes_ccm_encrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
                      uint8_t* ciphertext, uint8_t* tag, size_t tag_len) {
     if (!init_cc310()) return false;
     if (nonce_len < 7 || nonce_len > 13) {
-        writeSerial("ERROR: Invalid CCM nonce length: " + String((int)nonce_len));
+        od_log_error("ERROR: Invalid CCM nonce length: %d", (int)nonce_len);
         return false;
     }
     if (tag_len < 4 || tag_len > 16 || (tag_len % 2 != 0)) {
-        writeSerial("ERROR: Invalid CCM tag length: " + String((int)tag_len));
+        od_log_error("ERROR: Invalid CCM tag length: %d", (int)tag_len);
         return false;
     }
     CRYS_AESCCM_Key_t ccmKey;
@@ -500,7 +493,7 @@ bool aes_ccm_encrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
         (uint8_t*)plaintext, (uint32_t)plaintext_len,
         ciphertext, (uint8_t)tag_len, macRes);
     if (err != CRYS_OK) {
-        writeSerial("ERROR: CRYS_AESCCM (encrypt) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: CRYS_AESCCM (encrypt) failed: 0x%lX", (unsigned long)err);
         return false;
     }
     memcpy(tag, macRes, tag_len);
@@ -513,11 +506,11 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
                      uint8_t* plaintext, const uint8_t* tag, size_t tag_len) {
     if (!init_cc310()) return false;
     if (nonce_len < 7 || nonce_len > 13) {
-        writeSerial("ERROR: Invalid CCM nonce length: " + String((int)nonce_len));
+        od_log_error("ERROR: Invalid CCM nonce length: %d", (int)nonce_len);
         return false;
     }
     if (tag_len < 4 || tag_len > 16 || (tag_len % 2 != 0)) {
-        writeSerial("ERROR: Invalid CCM tag length: " + String((int)tag_len));
+        od_log_error("ERROR: Invalid CCM tag length: %d", (int)tag_len);
         return false;
     }
     CRYS_AESCCM_Key_t ccmKey;
@@ -533,7 +526,7 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
         (uint8_t*)ciphertext, (uint32_t)ciphertext_len,
         plaintext, (uint8_t)tag_len, macRes);
     if (err != CRYS_OK) {
-        writeSerial("ERROR: CRYS_AESCCM (decrypt) failed: 0x" + String((unsigned long)err, HEX));
+        od_log_error("ERROR: CRYS_AESCCM (decrypt) failed: 0x%lX", (unsigned long)err);
         return false;
     }
     return true;
@@ -541,12 +534,12 @@ bool aes_ccm_decrypt(const uint8_t* key, const uint8_t* nonce, size_t nonce_len,
 
 void secure_random(uint8_t* output, size_t len) {
     if (!init_cc310()) {
-        writeSerial("WARNING: CC310 not initialized, using non-secure random");
+        od_log_warn("WARNING: CC310 not initialized, using non-secure random");
         for (size_t i = 0; i < len; i++) output[i] = random(256);
         return;
     }
     if (!nRFCrypto.Random.generate(output, (uint16_t)len)) {
-        writeSerial("ERROR: CC310 RNG failed, using non-secure fallback");
+        od_log_error("ERROR: CC310 RNG failed, using non-secure fallback");
         for (size_t i = 0; i < len; i++) output[i] = random(256);
     }
 }
@@ -575,7 +568,7 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
     encryptionSession.last_auth_time = currentTime;
     if (len == 1 && data[0] == 0x00) {
         if (encryptionSession.authenticated && checkEncryptionSessionTimeout()) {
-            writeSerial("New authentication requested, clearing existing session");
+            od_log_info("New authentication requested, clearing existing session");
             clearEncryptionSession();
         }
         secure_random(encryptionSession.pending_server_nonce, 16);
@@ -587,7 +580,7 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
         memcpy(response + 3, encryptionSession.pending_server_nonce, 16);
         memcpy(response + 19, device_id, 4);
         sendResponse(response, sizeof(response));
-        writeSerial("Authentication challenge sent");
+        od_log_info("Authentication challenge sent");
         return false;
     }
     if (len == 32) {
@@ -596,7 +589,7 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
         memcpy(client_nonce, data, 16);
         memcpy(challenge_response, data + 16, 16);
         if (currentTime - encryptionSession.server_nonce_time > 30000) {
-            writeSerial("ERROR: Server nonce expired");
+            od_log_error("ERROR: Server nonce expired");
             uint8_t response[] = {RESP_ACK, RESP_AUTHENTICATE, AUTH_STATUS_ERROR};
             sendResponse(response, sizeof(response));
             return false;
@@ -609,13 +602,13 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
         memcpy(challenge_input + 32, device_id, 4);
         uint8_t expected_response[16];
         if (!aes_cmac(securityConfig.encryption_key, challenge_input, 36, expected_response)) {
-            writeSerial("ERROR: Failed to compute expected CMAC");
+            od_log_error("ERROR: Failed to compute expected CMAC");
             uint8_t response[] = {RESP_ACK, RESP_AUTHENTICATE, AUTH_STATUS_ERROR};
             sendResponse(response, sizeof(response));
             return false;
         }
         if (!constantTimeCompare(challenge_response, expected_response, 16)) {
-            writeSerial("ERROR: Authentication failed (wrong key)");
+            od_log_error("ERROR: Authentication failed (wrong key)");
             uint8_t response[] = {RESP_ACK, RESP_AUTHENTICATE, AUTH_STATUS_FAILED};
             sendResponse(response, sizeof(response));
             memset(encryptionSession.pending_server_nonce, 0, 16);
@@ -625,7 +618,7 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
         memcpy(encryptionSession.server_nonce, encryptionSession.pending_server_nonce, 16);
         if (!deriveSessionKey(securityConfig.encryption_key, client_nonce,
                               encryptionSession.pending_server_nonce, encryptionSession.session_key)) {
-            writeSerial("ERROR: Failed to derive session key");
+            od_log_error("ERROR: Failed to derive session key");
             uint8_t response[] = {RESP_ACK, RESP_AUTHENTICATE, AUTH_STATUS_ERROR};
             sendResponse(response, sizeof(response));
             return false;
@@ -640,7 +633,7 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
             if (encryptionSession.session_id[i] != 0) { session_id_valid = true; break; }
         }
         if (!session_id_valid) {
-            writeSerial("ERROR: Session ID is invalid (all zeros)!");
+            od_log_error("ERROR: Session ID is invalid (all zeros)!");
             uint8_t response[] = {RESP_ACK, RESP_AUTHENTICATE, AUTH_STATUS_ERROR};
             sendResponse(response, sizeof(response));
             return false;
@@ -660,7 +653,7 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
         memcpy(server_input + 16, client_nonce, 16);
         memcpy(server_input + 32, device_id, 4);
         if (!aes_cmac(encryptionSession.session_key, server_input, 36, server_response)) {
-            writeSerial("ERROR: Failed to compute server response");
+            od_log_error("ERROR: Failed to compute server response");
             clearEncryptionSession();
             uint8_t response[] = {RESP_ACK, RESP_AUTHENTICATE, AUTH_STATUS_ERROR};
             sendResponse(response, sizeof(response));
@@ -670,10 +663,10 @@ bool handleAuthenticate(uint8_t* data, uint16_t len) {
         response[0] = RESP_ACK; response[1] = RESP_AUTHENTICATE; response[2] = AUTH_STATUS_SUCCESS;
         memcpy(response + 3, server_response, 16);
         sendResponse(response, sizeof(response));
-        writeSerial("Authentication successful, session established");
+        od_log_info("Authentication successful, session established");
         return true;
     }
-    writeSerial("ERROR: Invalid authentication request format (len=" + String(len) + ")");
+    od_log_error("ERROR: Invalid authentication request format (len=%u)", len);
     uint8_t response[] = {RESP_ACK, RESP_AUTHENTICATE, AUTH_STATUS_ERROR};
     sendResponse(response, sizeof(response));
     return false;
@@ -685,14 +678,14 @@ bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plain
     if (!verifyNonceReplay(nonce_full)) {
         encryptionSession.integrity_failures++;
         if (encryptionSession.integrity_failures >= 3) {
-            writeSerial("Too many integrity failures, clearing session");
+            od_log_warn("Too many integrity failures, clearing session");
             clearEncryptionSession();
         }
         return false;
     }
     uint16_t encrypted_len = ciphertext_len;
     if (encrypted_len > 512) {
-        writeSerial("ERROR: Encrypted payload too large");
+        od_log_error("ERROR: Encrypted payload too large");
         return false;
     }
     uint8_t nonce[13];
@@ -701,7 +694,7 @@ bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plain
     ad[0] = (command_header >> 8) & 0xFF;
     ad[1] = command_header & 0xFF;
     if (encrypted_len == 0) {
-        writeSerial("ERROR: Encrypted payload is 0 bytes (should include length byte)");
+        od_log_error("ERROR: Encrypted payload is 0 bytes (should include length byte)");
         return false;
     }
     static uint8_t decrypted_with_length[512];
@@ -711,7 +704,7 @@ bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plain
     if (success) {
         uint8_t payload_length = decrypted_with_length[0];
         if (payload_length > encrypted_len - 1) {
-            writeSerial("ERROR: Invalid payload length in decrypted data");
+            od_log_error("ERROR: Invalid payload length in decrypted data");
             return false;
         }
         if (payload_length > 0) memcpy(plaintext, decrypted_with_length + 1, payload_length);
@@ -722,7 +715,7 @@ bool decryptCommand(uint8_t* ciphertext, uint16_t ciphertext_len, uint8_t* plain
     }
     encryptionSession.integrity_failures++;
     if (encryptionSession.integrity_failures >= 3) {
-        writeSerial("Too many integrity failures, clearing session");
+        od_log_warn("Too many integrity failures, clearing session");
         clearEncryptionSession();
     }
     return false;
@@ -744,7 +737,7 @@ bool encryptResponse(uint8_t* plaintext, uint16_t plaintext_len, uint8_t* cipher
     // 1-byte. No response reaches 255 B today; refuse rather than silently wrap
     // if one ever would.
     if (payload_len > 255) {
-        writeSerial("ERROR: Encrypted response payload exceeds 255 bytes");
+        od_log_error("ERROR: Encrypted response payload exceeds 255 bytes");
         return false;
     }
     payload_with_length[0] = payload_len & 0xFF;
@@ -777,8 +770,8 @@ String getChipIdHex() {
     while (hexId.length() < 6) {
         hexId = "0" + hexId;
     }
-    writeSerial("Chip ID: " + String(id1, HEX) + String(id2, HEX), true);
-    writeSerial("Using last 3 bytes: " + hexId, true);
+    od_log_debug("Chip ID: %08X%08X", (unsigned)id1, (unsigned)id2);
+    od_log_debug("Using last 3 bytes: %s", hexId.c_str());
     return hexId;
 #endif
 #ifdef TARGET_ESP32
@@ -789,15 +782,15 @@ String getChipIdHex() {
     while (hexId.length() < 6) {
         hexId = "0" + hexId;
     }
-    writeSerial("Chip ID: " + String(chipId, HEX), true);
-    writeSerial("Using chip ID: " + hexId, true);
+    od_log_debug("Chip ID: %06X", (unsigned)chipId);
+    od_log_debug("Using chip ID: %s", hexId.c_str());
     return hexId;
 #endif
     return "";
 }
 
 void secureEraseConfig() {
-    writeSerial("=== SECURE ERASE CONFIG ===", true);
+    od_log_info("=== SECURE ERASE CONFIG ===");
     static uint8_t zeroBuffer[512];
     memset(zeroBuffer, 0, sizeof(zeroBuffer));
 
@@ -814,7 +807,7 @@ void secureEraseConfig() {
                 written += toWrite;
             }
             file.close();
-            writeSerial("Config file securely erased (" + String(written) + " bytes)", true);
+            od_log_info("Config file securely erased (%zu bytes)", written);
         }
         InternalFS.remove(CONFIG_FILE_PATH_LOCAL);
     }
@@ -831,12 +824,12 @@ void secureEraseConfig() {
                 written += toWrite;
             }
             file.close();
-            writeSerial("Config file securely erased (" + String(written) + " bytes)", true);
+            od_log_info("Config file securely erased (%zu bytes)", written);
         }
         LittleFS.remove(CONFIG_FILE_PATH_LOCAL);
     }
 #endif
-    writeSerial("Config securely erased", true);
+    od_log_info("Config securely erased");
 }
 
 void checkResetPin() {
@@ -849,8 +842,8 @@ void checkResetPin() {
     bool pullup = (securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_PULLUP) != 0;
     bool pulldown = (securityConfig.flags & OD_SECURITY_FLAG_RESET_PIN_PULLDOWN) != 0;
 
-    writeSerial("Checking reset pin " + String(pin) + " (polarity: " + String(polarity ? "HIGH" : "LOW") +
-                ", pullup: " + String(pullup) + ", pulldown: " + String(pulldown) + ")", true);
+    od_log_debug("Checking reset pin %u (polarity: %s, pullup: %d, pulldown: %d)",
+                 pin, polarity ? "HIGH" : "LOW", pullup, pulldown);
 
 #ifdef TARGET_ESP32
     pinMode(pin, INPUT);
@@ -870,11 +863,11 @@ void checkResetPin() {
     bool pinState = digitalRead(pin);
 
     if (pinState == polarity) {
-        writeSerial("Reset pin triggered! Securely erasing config and rebooting...", true);
+        od_log_warn("Reset pin triggered! Securely erasing config and rebooting...");
         secureEraseConfig();
         delay(100);
         reboot();
     } else {
-        writeSerial("Reset pin not triggered (state: " + String(pinState ? "HIGH" : "LOW") + ")", true);
+        od_log_debug("Reset pin not triggered (state: %s)", pinState ? "HIGH" : "LOW");
     }
 }

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -92,7 +92,7 @@ public:
             if (!quiet) {
                 // One-line RX log, mirroring the "BLE: TX ..." response log.
                 uint16_t cmd = (len >= 2) ? ((data[0] << 8) | data[1]) : data[0];
-                char line[160];
+                char line[160] = {0};
                 int pos = snprintf(line, sizeof(line), "BLE: RX 0x%04X (%u B):", cmd, (unsigned)len);
                 if (pos < 0) {
                     pos = 0;

--- a/src/esp32_ble_callbacks.h
+++ b/src/esp32_ble_callbacks.h
@@ -6,6 +6,7 @@
 #include <Arduino.h>
 #include <string.h>
 #include "ble_init.h"   // NimBLE-Arduino + BLE* aliases
+#include "od_log.h"
 
 // Defined in display_service.cpp. True for a mid-stream image-write data frame
 // (0x0071) whose per-frame receive/queue logging should be suppressed.
@@ -45,7 +46,7 @@ class MyBLEServerCallbacks : public BLEServerCallbacks {
     void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) override {
         (void)pServer;
         (void)connInfo;
-        writeSerial("=== BLE CLIENT CONNECTED (ESP32) ===");
+        od_log_info("=== BLE CLIENT CONNECTED (ESP32) ===");
         rebootFlag = 0;
         esp32BleNotifySubscribed = false;
         // Flag-only: updatemsdata() polls I2C and mutates the shared advertisement
@@ -57,7 +58,7 @@ class MyBLEServerCallbacks : public BLEServerCallbacks {
         (void)pServer;
         (void)connInfo;
         (void)reason;
-        writeSerial("=== BLE CLIENT DISCONNECTED (ESP32) ===");
+        od_log_info("=== BLE CLIENT DISCONNECTED (ESP32) ===");
         esp32BleNotifySubscribed = false;
         // Flag-only: the session teardown below (EPD force-off with SPI.end()/rail
         // cut, partial + pipe cleanup) is heavyweight, state-mutating work that races
@@ -75,7 +76,7 @@ public:
         (void)pCharacteristic;
         (void)connInfo;
         esp32BleNotifySubscribed = (subValue & 0x0001) != 0;
-        writeSerial("BLE notify subscription: " + String(esp32BleNotifySubscribed ? "enabled" : "disabled"));
+        od_log_info("BLE notify subscription: %s", esp32BleNotifySubscribed ? "enabled" : "disabled");
     }
     void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) override {
         (void)connInfo;
@@ -91,16 +92,24 @@ public:
             if (!quiet) {
                 // One-line RX log, mirroring the "BLE: TX ..." response log.
                 uint16_t cmd = (len >= 2) ? ((data[0] << 8) | data[1]) : data[0];
-                char head[32];
-                snprintf(head, sizeof(head), "BLE: RX 0x%04X (%u B):", cmd, (unsigned)len);
-                String line = head;
-                for (int i = 0; i < len && i < 32; i++) {
-                    char b[4];
-                    snprintf(b, sizeof(b), " %02X", data[i]);
-                    line += b;
+                char line[160];
+                int pos = snprintf(line, sizeof(line), "BLE: RX 0x%04X (%u B):", cmd, (unsigned)len);
+                if (pos < 0) {
+                    pos = 0;
+                    line[0] = '\0';
                 }
-                if (len > 32) line += " ...";
-                writeSerial(line);
+                int dumpLen = (len < 32) ? len : 32;
+                for (int i = 0; i < dumpLen && pos < (int)sizeof(line); i++) {
+                    int n = snprintf(line + pos, sizeof(line) - pos, " %02X", data[i]);
+                    if (n < 0) {
+                        break;
+                    }
+                    pos += n;
+                }
+                if (len > 32 && pos >= 0 && pos < (int)sizeof(line)) {
+                    snprintf(line + pos, sizeof(line) - pos, " ...");
+                }
+                od_log_debug("%s", line);
             }
             // SPSC ring: publish head with RELEASE after the payload is fully written
             // so the consumer (main loop) never observes a slot before its bytes land.
@@ -113,12 +122,12 @@ public:
                 commandQueue[head].pending = true;
                 __atomic_store_n(&commandQueueHead, nextHead, __ATOMIC_RELEASE);
             } else {
-                writeSerial("ERROR: Command queue full, dropping command");
+                od_log_error("ERROR: Command queue full, dropping command");
             }
         } else if (value.length() > MAX_COMMAND_SIZE) {
-            writeSerial("WARNING: Command too large, dropping");
+            od_log_warn("WARNING: Command too large, dropping");
         } else {
-            writeSerial("WARNING: Empty data received");
+            od_log_warn("WARNING: Empty data received");
         }
     }
 };

--- a/src/factory_config.cpp
+++ b/src/factory_config.cpp
@@ -1,9 +1,8 @@
 #include "factory_config.h"
 #include "communication.h"
+#include "od_log.h"
 #include <Arduino.h>
 #include <string.h>
-
-void writeSerial(String message, bool newLine = true);
 
 static uint16_t toolboxOuterCrc(const uint8_t* data, uint32_t bodyLen) {
     uint16_t crc = 0xFFFF;
@@ -50,13 +49,13 @@ bool tryProvisionFactoryEmbed(void) {
         return false;
     }
 
-    writeSerial("No valid stored config; provisioning from factory embed...");
+    od_log_info("No valid stored config; provisioning from factory embed...");
     if (saveConfig(const_cast<uint8_t*>(g_factory_embed.data), g_factory_embed.len)) {
-        writeSerial("Factory config saved to filesystem");
+        od_log_info("Factory config saved to filesystem");
         return true;
     }
 
-    writeSerial("ERROR: Factory embed present but saveConfig failed");
+    od_log_error("ERROR: Factory embed present but saveConfig failed");
 #endif
     return false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,47 +60,50 @@ void setup() {
     #elif !defined(DISABLE_USB_SERIAL)
     od_log_init(&Serial);
     #endif
-    writeSerial("=== FIRMWARE INFO ===");
-    writeSerial("Firmware Version: " + String(getFirmwareMajor()) + "." + String(getFirmwareMinor()));
+    od_log_info("=== FIRMWARE INFO ===");
+    uint8_t fwMajor = getFirmwareMajor();
+    uint8_t fwMinor = getFirmwareMinor();
+    od_log_info("Firmware Version: %u.%u", fwMajor, fwMinor);
     const char* shaCStr = SHA_STRING;
     String shaStr = String(shaCStr);
     if (shaStr.length() >= 2 && shaStr.charAt(0) == '"' && shaStr.charAt(shaStr.length() - 1) == '"') {
         shaStr = shaStr.substring(1, shaStr.length() - 1);
     }
     if (shaStr.length() > 0 && shaStr != "\"\"" && shaStr != "") {
-        writeSerial("Git SHA: " + shaStr);
+        od_log_info("Git SHA: %s", shaStr.c_str());
     } else {
-        writeSerial("Git SHA: (not set)");
+        od_log_info("Git SHA: (not set)");
     }
     // Set only by the ESP32 wake-cause check below; NRF has no deep-sleep wake path.
     bool is_deep_sleep_wake = false;
     bool woke_by_button = false;
     #ifdef TARGET_ESP32
     esp_reset_reason_t reset_reason = esp_reset_reason();
-    writeSerial("Reset reason: " + String(resetReasonName(reset_reason)) + " (" + String((int)reset_reason) + ")");
+    const char* resetReasonStr = resetReasonName(reset_reason);
+    od_log_info("Reset reason: %s (%d)", resetReasonStr, (int)reset_reason);
     esp_sleep_wakeup_cause_t wakeup_reason = esp_sleep_get_wakeup_cause();
     is_deep_sleep_wake = (wakeup_reason != ESP_SLEEP_WAKEUP_UNDEFINED);
     if (is_deep_sleep_wake) {
         woke_from_deep_sleep = true;
         deep_sleep_count++;
-        writeSerial("=== WOKE FROM DEEP SLEEP ===");
+        od_log_info("=== WOKE FROM DEEP SLEEP ===");
         woke_by_button = detectButtonWake(wakeup_reason);  // logs the named cause + pin(s)
-        writeSerial("Deep sleep count: " + String(deep_sleep_count));
+        od_log_info("Deep sleep count: %u", deep_sleep_count);
     } else {
         woke_from_deep_sleep = false;
-        writeSerial("=== NORMAL BOOT ===");
+        od_log_info("=== NORMAL BOOT ===");
         // The bootloader reloads RTC memory segments from the app image on every
         // reset except a deep-sleep wake, so RTC_DATA_ATTR does NOT survive
         // panic/WDT/SW/brownout resets: a hidden mid-cycle reset lands here with
         // count 0, indistinguishable from a true first boot (captured on hardware
         // in docs/FINDINGS_DEEP_SLEEP_WAKE_BOOT_SCREEN_2026-07-07.md).
-        writeSerial("Deep sleep count (RTC): " + String(deep_sleep_count));
+        od_log_info("Deep sleep count (RTC): %u", deep_sleep_count);
     }
     #endif
-    writeSerial("Starting setup...");
-    if (is_deep_sleep_wake) { writeSerial("[wake] >> full_config_init"); flushLog(); }
+    od_log_info("Starting setup...");
+    if (is_deep_sleep_wake) { od_log_info("[wake] >> full_config_init"); od_log_flush(); }
     full_config_init();
-    if (is_deep_sleep_wake) { writeSerial("[wake] << full_config_init >> initio"); flushLog(); }
+    if (is_deep_sleep_wake) { od_log_info("[wake] << full_config_init >> initio"); od_log_flush(); }
     initio();
 #ifdef TARGET_NRF
     // SoftDevice must start before display/SPI; advertising starts after boot screen.
@@ -115,13 +118,13 @@ void setup() {
         // Wake keeps the panel image; skipping initDisplay() (EPD rail power +
         // full refresh) is the wake path's main energy saving.
         initDisplay();
-        writeSerial("Display initialized");
+        od_log_info("Display initialized");
     }
 #ifdef TARGET_ESP32
     // Full BLE after display: ESP32 queues commands for loop() until setup returns.
-    if (is_deep_sleep_wake) { writeSerial("[wake] >> ble_init"); flushLog(); }
+    if (is_deep_sleep_wake) { od_log_info("[wake] >> ble_init"); od_log_flush(); }
     ble_init();
-    if (is_deep_sleep_wake) { writeSerial("[wake] << ble_init"); flushLog(); }
+    if (is_deep_sleep_wake) { od_log_info("[wake] << ble_init"); od_log_flush(); }
 #elif defined(TARGET_NRF)
     ble_nrf_advertising_start();
 #endif
@@ -131,16 +134,16 @@ void setup() {
     }
     #endif
     updatemsdata();
-    if (is_deep_sleep_wake) { writeSerial("[wake] >> initButtons"); flushLog(); }
+    if (is_deep_sleep_wake) { od_log_info("[wake] >> initButtons"); od_log_flush(); }
     initButtons();
-    if (is_deep_sleep_wake) { writeSerial("[wake] >> initTouchInput"); flushLog(); }
+    if (is_deep_sleep_wake) { od_log_info("[wake] >> initTouchInput"); od_log_flush(); }
     initTouchInput();
     #ifdef TARGET_ESP32
     if (is_deep_sleep_wake) {
         // Arm the awake window LAST so buttons/GT911 bring-up doesn't shrink the
         // host's connection window. Without this, loop() falls into the idle
         // branch and re-enters deep sleep almost immediately.
-        writeSerial("Advertising for " + String(globalConfig.power_option.sleep_timeout_ms) + " ms (sleep_timeout_ms), waiting for connection...");
+        od_log_info("Advertising for %u ms (sleep_timeout_ms), waiting for connection...", globalConfig.power_option.sleep_timeout_ms);
         advertising_timeout_active = true;
         advertising_start_time = millis();
         if (woke_by_button) {
@@ -148,7 +151,8 @@ void setup() {
             // the minimum window so they (or a host) get time to interact.
             minWakeWindowActive = true;
             minWakeWindowStartMs = millis();
-            writeSerial("Button wake: holding awake >= " + String(minWakeTimeMs()) + " ms");
+            uint32_t minWakeMs = minWakeTimeMs();
+            od_log_info("Button wake: holding awake >= %u ms", (unsigned)minWakeMs);
         }
     } else if (deep_sleep_count == 0) {
         // First boot — or a hidden mid-cycle reset, which reloads the RTC count
@@ -160,7 +164,10 @@ void setup() {
     // Both sleep paths measure quiet time from here, not from power-on.
     lastActivityMs = millis();
     #endif
-    writeSerial("=== Setup completed successfully ===");
+    od_log_info("=== Setup completed successfully ===");
+#ifdef TARGET_ESP32
+    od_log_info("Heap: free=%u min=%u", (unsigned)ESP.getFreeHeap(), (unsigned)ESP.getMinFreeHeap());
+#endif
 }
 
 uint32_t getDeepSleepCount() {
@@ -186,7 +193,7 @@ static bool minWakeHoldActive() {
     if (!minWakeWindowActive) return false;
     if (millis() - minWakeWindowStartMs >= minWakeTimeMs()) {
         minWakeWindowActive = false;
-        writeSerial("Minimum wake window elapsed, deep sleep permitted");
+        od_log_info("Minimum wake window elapsed, deep sleep permitted");
         return false;
     }
     return true;
@@ -273,7 +280,7 @@ void flushResponseQueueToBle() {
             // (replaces the old "Sending queued response" + "Response sent successfully").
             if (!quietAck) {
                 uint8_t depth = (responseQueueHead - responseQueueTail + RESPONSE_QUEUE_SIZE) % RESPONSE_QUEUE_SIZE;
-                writeSerial("BLE Response Sent (queue size: " + String(depth) + ")");
+                od_log_debug("BLE Response Sent (queue size: %u)", depth);
             }
             bleDrain++;
         }
@@ -319,7 +326,7 @@ void loop() {
     // THIS IS THE MAIN (FIRST) LOOP FOR A DEEP SLEEP ENABLED ESP32
     if (woke_from_deep_sleep && advertising_timeout_active) {
         if (pServer && pServer->getConnectedCount() > 0) {
-            writeSerial("BLE connection established - switching to full mode");
+            od_log_info("BLE connection established - switching to full mode");
             advertising_timeout_active = false;
             fullSetupAfterConnection();
             woke_from_deep_sleep = false;
@@ -341,8 +348,9 @@ void loop() {
         // On a button wake the min-wake hold keeps this window open past the
         // quiet timeout; idleDelay(50) below services buttons/touch throughout.
         if (idle_duration >= advertising_timeout_ms && !minWakeHoldActive()) {
-            writeSerial("BLE advertising timeout (idle " + String(idle_duration) + " ms of " +
-                        String(millis() - advertising_start_time) + " ms window) - no connection, returning to deep sleep");
+            uint32_t advertisingElapsedMs = millis() - advertising_start_time;
+            od_log_info("BLE advertising timeout (idle %u ms of %u ms window) - no connection, returning to deep sleep",
+                        (unsigned)idle_duration, (unsigned)advertisingElapsedMs);
             advertising_timeout_active = false;
             enterDeepSleep();
             return;
@@ -395,7 +403,7 @@ void loop() {
     if (directWriteActive && directWriteStartTime > 0) {
         uint32_t directWriteDuration = millis() - directWriteStartTime;
         if (directWriteDuration > 900000UL) {  // 15 minute timeout (upload + refresh window)
-            writeSerial("ERROR: Direct write timeout (" + String(directWriteDuration) + " ms) - cleaning up stuck state");
+            od_log_error("ERROR: Direct write timeout (%u ms) - cleaning up stuck state", (unsigned)directWriteDuration);
             cleanupDirectWriteState(true);
         }
     }
@@ -406,14 +414,16 @@ void loop() {
     static uint32_t lastWiFiCheck = 0;
     if (wifiInitialized && (millis() - lastWiFiCheck > 10000)) {
         lastWiFiCheck = millis();
-        if (WiFi.status() != WL_CONNECTED && wifiConnected) {
-            writeSerial("WiFi connection lost (status: " + String(WiFi.status()) + ")");
+        wl_status_t wifiStatus = WiFi.status();
+        if (wifiStatus != WL_CONNECTED && wifiConnected) {
+            od_log_warn("WiFi connection lost (status: %d)", wifiStatus);
             wifiConnected = false;
             if (wifiServerConnected) {
                 disconnectWiFiServer();
             }
-        } else if (WiFi.status() == WL_CONNECTED && !wifiConnected) {
-            writeSerial("WiFi reconnected (IP: " + WiFi.localIP().toString() + ")");
+        } else if (wifiStatus == WL_CONNECTED && !wifiConnected) {
+            String wifiIp = WiFi.localIP().toString();
+            od_log_info("WiFi reconnected (IP: %s)", wifiIp.c_str());
             wifiConnected = true;
             restartWiFiLanAfterReconnect();
         }
@@ -449,7 +459,7 @@ void loop() {
             if (idleMs < idleHoldMs || minWakeHoldActive()) {
                 idleDelay(5);
             } else {
-                writeSerial("Idle " + String(idleMs) + " ms (hold " + String(idleHoldMs) + " ms) - entering deep sleep");
+                od_log_info("Idle %u ms (hold %u ms) - entering deep sleep", (unsigned)idleMs, (unsigned)idleHoldMs);
                 enterDeepSleep();
             }
         }
@@ -508,38 +518,38 @@ void idleDelay(uint32_t delayMs) {
 
 #ifdef TARGET_ESP32
 void fullSetupAfterConnection() {
-    writeSerial("=== Full Setup After Connection ===");
+    od_log_info("=== Full Setup After Connection ===");
     initWiFi(false);
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_FASTEPD)
     if (globalConfig.display_count > 0 && fastepd_driver_used()) {
-        writeSerial("Panel: FastEPD ED103/IT8951 (bb_epaper not used)", true);
-        writeSerial("=== Full setup completed ===");
+        od_log_info("Panel: FastEPD ED103/IT8951 (bb_epaper not used)");
+        od_log_info("=== Full setup completed ===");
         return;
     }
 #endif
     if (globalConfig.display_count > 0) {
         memset(&bbep, 0, sizeof(BBEPDISP));
         int panelType = mapEpd(globalConfig.displays[0].panel_ic_type);
-        writeSerial("Panel type: " + String(panelType));
+        od_log_info("Panel type: %d", panelType);
         bbepSetPanelType(&bbep, panelType);
         bbepSetRotation(&bbep, globalConfig.displays[0].rotation * 90);
     }
-    writeSerial("=== Full setup completed ===");
+    od_log_info("=== Full setup completed ===");
 }
 
 void enterDeepSleep(bool force, uint16_t overrideSleepSeconds) {
     if (globalConfig.power_option.power_mode != 1) {
-        writeSerial("Skipping deep sleep - not battery powered (power_mode: " + String(globalConfig.power_option.power_mode) + ")");
+        od_log_debug("Skipping deep sleep - not battery powered (power_mode: %u)", globalConfig.power_option.power_mode);
         return;
     }
     if (globalConfig.power_option.deep_sleep_time_seconds == 0) {
-        writeSerial("Skipping deep sleep - deep_sleep_time_seconds is 0");
+        od_log_debug("Skipping deep sleep - deep_sleep_time_seconds is 0");
         return;
     }
     // Callers sample their idle state before getting here; a central can connect in
     // that gap. Re-check so we never tear down the stack on a live link.
     if (!force && pServer != nullptr && pServer->getConnectedCount() > 0) {
-        writeSerial("Skipping deep sleep - BLE client connected");
+        od_log_debug("Skipping deep sleep - BLE client connected");
         lastActivityMs = millis();
         return;
     }
@@ -548,7 +558,7 @@ void enterDeepSleep(bool force, uint16_t overrideSleepSeconds) {
     // commits to esp_deep_sleep_start(), so a late abort would leave the device
     // awake with the radio dark. force (host 0x0053) bypasses the hold.
     if (!force && minWakeHoldActive()) {
-        writeSerial("Skipping deep sleep - minimum wake window active");
+        od_log_debug("Skipping deep sleep - minimum wake window active");
         return;
     }
     // Panel power-down MUST sit below every early-return above (including the
@@ -565,14 +575,14 @@ void enterDeepSleep(bool force, uint16_t overrideSleepSeconds) {
         BLEAdvertising *pAdvertising = pServer->getAdvertising();
         if (pAdvertising != nullptr) {
             pAdvertising->stop();
-            writeSerial("BLE advertising stopped");
+            od_log_info("BLE advertising stopped");
         }
     }
     delay(200);
     BLEDevice::deinit(true);
     esp32_ble_clear_handles();
     delay(100);
-    writeSerial("BLE deinitialized");
+    od_log_info("BLE deinitialized");
     // Host override (0x0053 payload) applies to this one cycle only: it is a
     // parameter, never stored, so an aborted or later sleep reverts to config.
     uint16_t sleepSeconds = overrideSleepSeconds ? overrideSleepSeconds
@@ -583,9 +593,10 @@ void enterDeepSleep(bool force, uint16_t overrideSleepSeconds) {
     // manipulation then cannot disturb freshly configured RTC pulls, and its
     // gpio_hold_en() touches only the latch pin, never the wake pads.
     armButtonWakeSources();
-    writeSerial("Entering deep sleep for " + String(sleepSeconds) + " seconds" +
-                (overrideSleepSeconds ? " (host override, one cycle)" : " (config)"));
-    flushLog(); // Arduino drain UART/Serial prior to deep sleep
+    od_log_info("Entering deep sleep for %u seconds%s", sleepSeconds,
+                overrideSleepSeconds ? " (host override, one cycle)" : " (config)");
+    od_log_info("Heap: free=%u min=%u", (unsigned)ESP.getFreeHeap(), (unsigned)ESP.getMinFreeHeap());
+    od_log_flush(); // drain UART/Serial prior to deep sleep
     delay(100); // Brief delay to ensure serial output is sent
     powerLatchHoldForSleep();
     esp_deep_sleep_start();
@@ -623,7 +634,7 @@ static void configureDisplayPinsLowPower() {
 
 void pwrmgm(bool onoff){
     if(globalConfig.display_count == 0){
-        writeSerial("No display configured");
+        od_log_warn("No display configured");
         return;
     }
     // Idempotency guard keyed on the panel power state machine (the single source
@@ -647,11 +658,11 @@ void pwrmgm(bool onoff){
     }
     if(axp2101_found){
         if(onoff){
-        writeSerial("Powering up AXP2101 PMIC...");
+        od_log_info("Powering up AXP2101 PMIC...");
             initAXP2101(axp2101_bus_id);
         }
         else{
-            writeSerial("Powering down AXP2101 PMIC...");
+            od_log_info("Powering down AXP2101 PMIC...");
             powerDownAXP2101();
             Wire.end();
             invalidateOpenDisplayWire();
@@ -672,7 +683,7 @@ void pwrmgm(bool onoff){
             digitalWrite(globalConfig.system_config.pwr_pin, HIGH);
             delay(800);
         } else {
-            writeSerial("Power pin not set");
+            od_log_warn("Power pin not set");
         }
         if (!fastepd_driver_spi) {
             if (disp.reset_pin != 0xFF) {
@@ -758,7 +769,7 @@ void xiaoinit(){
 }
 
 void ws_pp_init(){
-    writeSerial("===  Photo Printer Initialization ===");
+    od_log_info("===  Photo Printer Initialization ===");
     pinMode(21, OUTPUT);
     digitalWrite(21, HIGH);
     pinMode(1, INPUT);
@@ -787,7 +798,7 @@ void ws_pp_init(){
     digitalWrite(42, HIGH);
     pinMode(45, OUTPUT);
     digitalWrite(45, HIGH);
-    writeSerial("Photo Printer initialized");
+    od_log_info("Photo Printer initialized");
 }
 
 #ifdef TARGET_NRF
@@ -809,10 +820,10 @@ void powerDownExternalFlashFromConfig(void) {
     const uint8_t sckPin = flashCfg->sck_pin;
     const uint8_t csPin = flashCfg->cs_pin;
     if (mosiPin == 0xFF || sckPin == 0xFF || csPin == 0xFF) {
-        writeSerial("Flash config: invalid MOSI/SCK/CS pins", true);
+        od_log_warn("Flash config: invalid MOSI/SCK/CS pins");
         return;
     }
-    writeSerial("Flash config: deep sleep MOSI=" + String(mosiPin) + " SCK=" + String(sckPin) + " CS=" + String(csPin), true);
+    od_log_debug("Flash config: deep sleep MOSI=%u SCK=%u CS=%u", mosiPin, sckPin, csPin);
 
     pinMode(mosiPin, OUTPUT);
     pinMode(sckPin, OUTPUT);
@@ -858,29 +869,30 @@ bool powerDownExternalFlash(uint8_t mosiPin, uint8_t misoPin, uint8_t sckPin, ui
         }
         return result;
     };
-    writeSerial("=== External Flash Power-Down ===");
-    writeSerial("Pin configuration: MOSI=" + String(mosiPin) + " MISO=" + String(misoPin) + " SCK=" + String(sckPin) + " CS=" + String(csPin) + " WP=" + String(wpPin) + " HOLD=" + String(holdPin));
-    writeSerial("Configuring SPI pins...");
+    od_log_info("=== External Flash Power-Down ===");
+    od_log_debug("Pin configuration: MOSI=%u MISO=%u SCK=%u CS=%u WP=%u HOLD=%u",
+                 mosiPin, misoPin, sckPin, csPin, wpPin, holdPin);
+    od_log_debug("Configuring SPI pins...");
     pinMode(mosiPin, OUTPUT);
     pinMode(misoPin, INPUT);
     pinMode(sckPin, OUTPUT);
     pinMode(csPin, OUTPUT);
     pinMode(wpPin, OUTPUT);
     pinMode(holdPin, OUTPUT);
-    writeSerial("SPI pins configured");
+    od_log_debug("SPI pins configured");
     digitalWrite(sckPin, HIGH);  // Clock idle high (SPI mode 0)
     digitalWrite(csPin, HIGH);   // CS inactive
     digitalWrite(wpPin, HIGH);   // WP disabled (active-low)
     digitalWrite(holdPin, HIGH); // HOLD disabled (active-low)
-    writeSerial("Control pins set: CS=HIGH, WP=HIGH (disabled), HOLD=HIGH (disabled), SCK=HIGH (idle)");
+    od_log_debug("Control pins set: CS=HIGH, WP=HIGH (disabled), HOLD=HIGH (disabled), SCK=HIGH (idle)");
     delay(1);
-    writeSerial("Attempting to wake flash from deep power-down (command 0xAB)...");
+    od_log_debug("Attempting to wake flash from deep power-down (command 0xAB)...");
     digitalWrite(csPin, LOW);
     spiTransfer(0xAB);
     digitalWrite(csPin, HIGH);
     delay(10); // Wait for flash to wake up (typically 3-35us, using 10ms for safety)
-    writeSerial("Wake-up command sent, waiting 10ms...");
-    writeSerial("Reading JEDEC ID before power-down...");
+    od_log_debug("Wake-up command sent, waiting 10ms...");
+    od_log_debug("Reading JEDEC ID before power-down...");
     digitalWrite(csPin, LOW);
     spiTransfer(0x9F); // JEDEC ID command
     uint8_t jedecId[3];
@@ -888,22 +900,17 @@ bool powerDownExternalFlash(uint8_t mosiPin, uint8_t misoPin, uint8_t sckPin, ui
         jedecId[i] = spiTransfer(0x00);
     }
     digitalWrite(csPin, HIGH);
-    String jedecIdStr = "0x";
-    for (int i = 0; i < 3; i++) {
-        if (jedecId[i] < 16) jedecIdStr += "0";
-        jedecIdStr += String(jedecId[i], HEX);
-    }
-    jedecIdStr.toUpperCase();
-    writeSerial("JEDEC ID before: " + jedecIdStr + " (Manufacturer=0x" + String(jedecId[0], HEX) + ", MemoryType=0x" + String(jedecId[1], HEX) + ", Capacity=0x" + String(jedecId[2], HEX) + ")");
+    od_log_debug("JEDEC ID before: 0x%02X%02X%02X (Manufacturer=0x%02X, MemoryType=0x%02X, Capacity=0x%02X)",
+                 jedecId[0], jedecId[1], jedecId[2], jedecId[0], jedecId[1], jedecId[2]);
     delay(1);
-    writeSerial("Sending deep power-down command (0xB9)...");
+    od_log_debug("Sending deep power-down command (0xB9)...");
     digitalWrite(csPin, LOW);
     spiTransfer(0xB9);
     digitalWrite(csPin, HIGH);
     if(false){
-    writeSerial("Deep power-down command sent, waiting 10ms...");
+    od_log_debug("Deep power-down command sent, waiting 10ms...");
     delay(10); // Wait for command to complete
-    writeSerial("Reading JEDEC ID after power-down command...");
+    od_log_debug("Reading JEDEC ID after power-down command...");
     digitalWrite(csPin, LOW);
     spiTransfer(0x9F);
     uint8_t jedecIdAfter[3];
@@ -911,13 +918,8 @@ bool powerDownExternalFlash(uint8_t mosiPin, uint8_t misoPin, uint8_t sckPin, ui
         jedecIdAfter[i] = spiTransfer(0x00);
     }
     digitalWrite(csPin, HIGH);
-    String jedecIdAfterStr = "0x";
-    for (int i = 0; i < 3; i++) {
-        if (jedecIdAfter[i] < 16) jedecIdAfterStr += "0";
-        jedecIdAfterStr += String(jedecIdAfter[i], HEX);
-    }
-    jedecIdAfterStr.toUpperCase();
-    writeSerial("JEDEC ID after: " + jedecIdAfterStr + " (byte[0]=0x" + String(jedecIdAfter[0], HEX) + ", byte[1]=0x" + String(jedecIdAfter[1], HEX) + ", byte[2]=0x" + String(jedecIdAfter[2], HEX) + ")");
+    od_log_debug("JEDEC ID after: 0x%02X%02X%02X (byte[0]=0x%02X, byte[1]=0x%02X, byte[2]=0x%02X)",
+                 jedecIdAfter[0], jedecIdAfter[1], jedecIdAfter[2], jedecIdAfter[0], jedecIdAfter[1], jedecIdAfter[2]);
     }
     // CS/WP/HOLD are active-low: keep HIGH so the chip stays deselected and in deep sleep.
     // CLK/MOSI/MISO LOW — defined idle levels, no floating buffers on the MCU side.
@@ -932,7 +934,7 @@ bool powerDownExternalFlash(uint8_t mosiPin, uint8_t misoPin, uint8_t sckPin, ui
         digitalWrite(pin, HIGH);
     }
     #else
-    writeSerial("External flash power-down not implemented for ESP32");
+    od_log_warn("External flash power-down not implemented for ESP32");
     return false;
     #endif
     return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -734,31 +734,6 @@ void pwrmgm(bool onoff){
     }
 }
 
-void writeSerial(String message, bool newLine){
-    #if defined(TARGET_ESP32) && defined(OPENDISPLAY_LOG_UART)
-    if (newLine) LogSerialPort.println(message);
-    else LogSerialPort.print(message);
-    #elif !defined(DISABLE_USB_SERIAL)
-    if (newLine == true) Serial.println(message);
-    else Serial.print(message);
-    #endif
-}
-
-// Blocks until the log UART has physically drained. The IDF panic handler only
-// flushes the console UART, so without this the last lines before a crash are
-// lost on the OPENDISPLAY_LOG_UART port — call after a marker to guarantee it
-// reaches the wire before a suspect call can fault.
-void flushLog(){
-    #if defined(TARGET_ESP32) && defined(OPENDISPLAY_LOG_UART)
-    LogSerialPort.flush();
-    #elif !defined(DISABLE_USB_SERIAL)
-    Serial.flush();
-    #endif
-    #ifdef TARGET_ESP32
-    delay(5);
-    #endif
-}
-
 void xiaoinit(){
     powerDownExternalFlash(20,24,21,25,22,23);
     //pinMode(31, INPUT);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "touch_input.h"
 #include "encryption.h"
 #include "ble_init.h"
+#include "od_log.h"
 
 #if defined(TARGET_ESP32) && defined(OPENDISPLAY_LOG_UART)
 #include <HardwareSerial.h>
@@ -53,6 +54,11 @@ void setup() {
     #elif !defined(DISABLE_USB_SERIAL)
     Serial.begin(115200);
     delay(100);
+    #endif
+    #if defined(TARGET_ESP32) && defined(OPENDISPLAY_LOG_UART)
+    od_log_init(&LogSerialPort);
+    #elif !defined(DISABLE_USB_SERIAL)
+    od_log_init(&Serial);
     #endif
     writeSerial("=== FIRMWARE INFO ===");
     writeSerial("Firmware Version: " + String(getFirmwareMajor()) + "." + String(getFirmwareMinor()));
@@ -155,6 +161,14 @@ void setup() {
     lastActivityMs = millis();
     #endif
     writeSerial("=== Setup completed successfully ===");
+}
+
+uint32_t getDeepSleepCount() {
+#ifdef TARGET_ESP32
+    return deep_sleep_count;
+#else
+    return 0;
+#endif
 }
 
 #ifdef TARGET_ESP32

--- a/src/main.h
+++ b/src/main.h
@@ -180,8 +180,6 @@ bool powerDownExternalFlash(uint8_t mosiPin, uint8_t misoPin, uint8_t sckPin, ui
 void powerDownExternalFlashFromConfig(void);
 void xiaoinit();
 void ws_pp_init();
-void writeSerial(String message, bool newLine = true);
-void flushLog();
 void connect_callback(uint16_t conn_handle);
 void disconnect_callback(uint16_t conn_handle, uint8_t reason);
 #ifdef TARGET_ESP32

--- a/src/main.h
+++ b/src/main.h
@@ -250,6 +250,7 @@ void handlePartialWriteStart(uint8_t* data, uint16_t len);
 int mapEpd(int id);
 uint8_t getFirmwareMajor();
 uint8_t getFirmwareMinor();
+uint32_t getDeepSleepCount();  // RTC-persisted wake cycle count on ESP32; always 0 on nRF52840
 float readBatteryVoltage();  // Returns battery voltage in volts, or -1.0 if not configured
 float readChipTemperature();  // Returns chip temperature in degrees Celsius
 int getplane();

--- a/src/od_log.cpp
+++ b/src/od_log.cpp
@@ -1,0 +1,66 @@
+#include "od_log.h"
+#include <stdarg.h>
+#include <stdio.h>
+
+// Implemented in main.cpp: RTC-persisted wake cycle count on ESP32, always 0 on nRF52840.
+uint32_t getDeepSleepCount();
+
+// Log output destination, set once by od_log_init(). Stays NULL if
+// od_log_init() is never called (e.g. DISABLE_USB_SERIAL builds), in which
+// case all log calls become no-ops.
+static Stream *s_port = NULL;
+
+static const char level_chars[] = "EWID";
+
+void od_log_init(Stream *port) {
+    s_port = port;
+}
+
+void _od_log(int level, const char *fmt, ...) {
+    if (s_port == NULL) {
+        return;
+    }
+
+    char buf[256];
+    unsigned long ms = millis();
+    unsigned long cycleCount = (unsigned long)getDeepSleepCount();
+    int pos = snprintf(buf, sizeof(buf), "[%04lu.%03lu|C%lu] %c: ",
+                        ms / 1000, ms % 1000,
+                        cycleCount,
+                        level_chars[level]);
+    if (pos < 0) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buf + pos, sizeof(buf) - pos, fmt, args);
+    va_end(args);
+
+    s_port->println(buf);
+}
+
+void od_log_raw(const char *fmt, ...) {
+    if (s_port == NULL) {
+        return;
+    }
+
+    char buf[256];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    s_port->print(buf);
+}
+
+void od_log_flush(void) {
+    if (s_port == NULL) {
+        return;
+    }
+
+    s_port->flush();
+    #ifdef TARGET_ESP32
+    delay(5);
+    #endif
+}

--- a/src/od_log.h
+++ b/src/od_log.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Timestamped, allocation-free logging.
+//
+// Call od_log_init() once in setup() right after the serial port's begin().
+// Levels are filtered at compile time via OD_LOG_LEVEL, so disabled levels
+// compile to nothing.
+
+#define OD_LOG_ERROR 0
+#define OD_LOG_WARN  1
+#define OD_LOG_INFO  2
+#define OD_LOG_DEBUG 3
+
+#ifndef OD_LOG_LEVEL
+#define OD_LOG_LEVEL OD_LOG_INFO
+#endif
+
+#define od_log_error(fmt, ...) do { if (OD_LOG_LEVEL >= OD_LOG_ERROR) \
+    _od_log(OD_LOG_ERROR, fmt, ##__VA_ARGS__); } while (0)
+#define od_log_warn(fmt, ...)  do { if (OD_LOG_LEVEL >= OD_LOG_WARN) \
+    _od_log(OD_LOG_WARN, fmt, ##__VA_ARGS__); } while (0)
+#define od_log_info(fmt, ...)  do { if (OD_LOG_LEVEL >= OD_LOG_INFO) \
+    _od_log(OD_LOG_INFO, fmt, ##__VA_ARGS__); } while (0)
+#define od_log_debug(fmt, ...) do { if (OD_LOG_LEVEL >= OD_LOG_DEBUG) \
+    _od_log(OD_LOG_DEBUG, fmt, ##__VA_ARGS__); } while (0)
+
+void od_log_init(Stream *port);
+void _od_log(int level, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+void od_log_raw(const char *fmt, ...)         __attribute__((format(printf, 1, 2)));
+void od_log_flush(void);

--- a/src/sensor_bq27220.cpp
+++ b/src/sensor_bq27220.cpp
@@ -1,13 +1,13 @@
 #include "sensor_bq27220.h"
 #include "structs.h"
 #include "display_service.h"
+#include "od_log.h"
 
 #include <Arduino.h>
 #include <Wire.h>
 
 extern struct GlobalConfig globalConfig;
 extern uint8_t dynamicreturndata[11];
-void writeSerial(String message, bool newLine = true);
 
 static_assert(sizeof(SensorData) == 30, "SensorData must remain 30 bytes");
 
@@ -127,15 +127,16 @@ void initBq27220Sensors(void) {
         return;
     }
     if (!bq27220_ensure_bus(s)) {
-        writeSerial("BQ27220: bus init failed", true);
+        od_log_warn("BQ27220: bus init failed");
         return;
     }
+    const uint8_t addr = bq27220_addr_7bit(s);
     uint8_t raw[2];
     if (!bq27220_read_block(s, BQ27220_CMD_VOLTAGE, raw, 2)) {
-        writeSerial("BQ27220: not found @0x" + String(bq27220_addr_7bit(s), HEX), true);
+        od_log_warn("BQ27220: not found @0x%02X", addr);
         return;
     }
-    writeSerial("BQ27220: fuel gauge @0x" + String(bq27220_addr_7bit(s), HEX), true);
+    od_log_info("BQ27220: fuel gauge @0x%02X", addr);
 }
 
 static constexpr uint32_t kBq27220MsdPollTtlMs = 30000u;

--- a/src/sensor_sht40.cpp
+++ b/src/sensor_sht40.cpp
@@ -1,13 +1,13 @@
 #include "sensor_sht40.h"
 #include "structs.h"
 #include "display_service.h"
+#include "od_log.h"
 
 #include <Arduino.h>
 #include <Wire.h>
 
 extern struct GlobalConfig globalConfig;
 extern uint8_t dynamicreturndata[11];
-void writeSerial(String message, bool newLine = true);
 
 static_assert(sizeof(SensorData) == 30, "SensorData must remain 30 bytes");
 
@@ -168,7 +168,7 @@ static void sht40_probe_bus_once(uint8_t bus_id) {
     for (uint8_t i = 0; i < sizeof(addrs); i++) {
         Wire.beginTransmission(addrs[i]);
         uint8_t err = Wire.endTransmission();
-        writeSerial("I2C bus " + String(bus_id) + " probe 0x" + String(addrs[i], HEX) + " err=" + String(err), true);
+        od_log_debug("I2C bus %u probe 0x%02X err=%u", bus_id, addrs[i], err);
     }
 }
 
@@ -262,9 +262,8 @@ void pollSht40SensorsForMsd(void) {
         if (!read_sht40_sample(s, &tc, &rhc, &err)) {
             if (!logged_fail) {
                 uint8_t bid = sht40_bus_id(s);
-                writeSerial("SHT40: read failed err=" + String(err) +
-                    " (I2C bus " + String(bid) + " SCL=GPIO" + String(globalConfig.data_buses[bid].pin_1) +
-                    " SDA=GPIO" + String(globalConfig.data_buses[bid].pin_2) + ")", true);
+                od_log_warn("SHT40: read failed err=%u (I2C bus %u SCL=GPIO%u SDA=GPIO%u)",
+                    err, bid, globalConfig.data_buses[bid].pin_1, globalConfig.data_buses[bid].pin_2);
                 logged_fail = true;
             }
             write_sht40_invalid(start);

--- a/src/touch_input.cpp
+++ b/src/touch_input.cpp
@@ -1,6 +1,7 @@
 #include "touch_input.h"
 #include "display_service.h"
 #include "structs.h"
+#include "od_log.h"
 #include <Arduino.h>
 #include <Wire.h>
 #include <string.h>
@@ -17,7 +18,6 @@ extern uint8_t dynamicreturndata[11];
 extern bool directWriteActive;
 #endif
 void updatemsdata(void);
-void writeSerial(String message, bool newLine = true);
 
 static_assert(sizeof(TouchController) == 32, "TouchController must be 32 bytes for packet 0x28");
 
@@ -108,7 +108,7 @@ static void touch_disable_controller(uint8_t idx, TouchController* tc, TouchRunt
         s_touch_irq_mask &= (uint8_t)~(1u << idx);
         interrupts();
     }
-    writeSerial("Touch[" + String(idx) + "]: disabled (" + String(reason) + ")", true);
+    od_log_warn("Touch[%u]: disabled (%s)", idx, reason);
 }
 
 void touchSuspendForEpdRefresh(void) {
@@ -167,7 +167,7 @@ static void attach_touch_int(uint8_t idx, uint8_t pin) {
     }
     int irq_num = digitalPinToInterrupt(pin);
     if (irq_num < 0) {
-        writeSerial("Touch[" + String(idx) + "]: digitalPinToInterrupt failed for GPIO " + String(pin) + " — using poll only", true);
+        od_log_warn("Touch[%u]: digitalPinToInterrupt failed for GPIO %u — using poll only", idx, pin);
         return;
     }
     pinMode(pin, INPUT_PULLUP);
@@ -222,18 +222,18 @@ static bool gt911_probe_product(uint8_t addr7, uint8_t* reg_high_first) {
     if (gt911_read_reg(addr7, GT911_REG_PID, id, 4, false) && gt911_product_id_match(id)) {
         *reg_high_first = 0;
 #if TOUCH_DEBUG
-        writeSerial("GT911: PID OK @0x" + String(addr7, HEX) + " LE", true);
+        od_log_debug("GT911: PID OK @0x%02X LE", addr7);
 #endif
         return true;
     }
     if (gt911_read_reg(addr7, GT911_REG_PID, id, 4, true) && gt911_product_id_match(id)) {
         *reg_high_first = 1;
 #if TOUCH_DEBUG
-        writeSerial("GT911: PID OK @0x" + String(addr7, HEX) + " BE", true);
+        od_log_debug("GT911: PID OK @0x%02X BE", addr7);
 #endif
         return true;
     }
-    writeSerial("GT911: PID probe failed at 0x" + String(addr7, HEX), true);
+    od_log_debug("GT911: PID probe failed at 0x%02X", addr7);
     return false;
 }
 
@@ -322,7 +322,7 @@ static uint8_t gt911_resolve_and_init(const TouchController* t, TouchRuntime* rt
         if (gt911_probe_product(want, &rt->reg_high_first)) {
             return want;
         }
-        writeSerial("GT911: probe failed at configured addr 0x" + String(want, HEX), true);
+        od_log_warn("GT911: probe failed at configured addr 0x%02X", want);
         return 0;
     }
 
@@ -347,7 +347,7 @@ static uint8_t gt911_resolve_and_init(const TouchController* t, TouchRuntime* rt
             return a14;
         }
     }
-    writeSerial("GT911: not found on I2C (check wiring, pull-ups, RST/INT)", true);
+    od_log_warn("GT911: not found on I2C (check wiring, pull-ups, RST/INT)");
     return 0;
 }
 
@@ -433,11 +433,11 @@ void touchResumeAfterEpdRefresh(void) {
             continue;
         }
         if (touch_light_resume_gt911(i, tc, rt)) {
-            writeSerial("Touch[" + String(i) + "]: light resume after EPD @0x" + String(rt->addr7, HEX), true);
+            od_log_debug("Touch[%u]: light resume after EPD @0x%02X", i, rt->addr7);
         } else if (touch_reinit_gt911(i, tc, rt)) {
-            writeSerial("Touch[" + String(i) + "]: reinit OK after EPD @0x" + String(rt->addr7, HEX), true);
+            od_log_debug("Touch[%u]: reinit OK after EPD @0x%02X", i, rt->addr7);
         } else {
-            writeSerial("Touch[" + String(i) + "]: reinit failed after EPD refresh", true);
+            od_log_warn("Touch[%u]: reinit failed after EPD refresh", i);
         }
     }
 }
@@ -488,7 +488,7 @@ void initTouchInput(void) {
         return;
     }
 #if TOUCH_DEBUG
-    writeSerial("Touch: init " + String(enabled) + " enabled / " + String(globalConfig.touch_controller_count) + " packet(s)", true);
+    od_log_debug("Touch: init %u enabled / %u packet(s)", enabled, globalConfig.touch_controller_count);
 #endif
     for (uint8_t i = 0; i < globalConfig.touch_controller_count; i++) {
         TouchController* tc = &globalConfig.touch_controllers[i];
@@ -498,18 +498,18 @@ void initTouchInput(void) {
         }
         if (tc->touch_ic_type != OD_TOUCH_IC_GT911) {
             if (tc->touch_ic_type != OD_TOUCH_IC_NONE) {
-                writeSerial("Touch[" + String(i) + "]: skipped (only GT911=1 implemented, got " + String(tc->touch_ic_type) + ")", true);
+                od_log_warn("Touch[%u]: skipped (only GT911=1 implemented, got %u)", i, tc->touch_ic_type);
             }
             continue;
         }
         touch_apply_enable_pin(tc);
         if (!touch_bus_ok(tc)) {
-            writeSerial("Touch[" + String(i) + "]: invalid I2C data_bus " + String(touch_bus_id(tc)) +
-                        " (data_bus_count=" + String(globalConfig.data_bus_count) + ")", true);
+            uint8_t busId = touch_bus_id(tc);
+            od_log_warn("Touch[%u]: invalid I2C data_bus %u (data_bus_count=%u)", i, busId, globalConfig.data_bus_count);
             continue;
         }
         if (tc->touch_data_start_byte > 6u) {
-            writeSerial("Touch[" + String(i) + "]: touch_data_start_byte must be 0–6 (5-byte window)", true);
+            od_log_warn("Touch[%u]: touch_data_start_byte must be 0–6 (5-byte window)", i);
             continue;
         }
         if (prior_rt[i].ok && prior_rt[i].addr7 != 0) {
@@ -518,7 +518,7 @@ void initTouchInput(void) {
             rt->disabled = 0;
             rt->i2c_fail_streak = 0;
             if (!touch_ensure_bus(tc)) {
-                writeSerial("Touch[" + String(i) + "]: bus restore failed after EPD", true);
+                od_log_warn("Touch[%u]: bus restore failed after EPD", i);
                 rt->ok = 0;
                 continue;
             }
@@ -527,13 +527,13 @@ void initTouchInput(void) {
                 gt911_int_wake_before_irq(tc);
                 attach_touch_int(i, tc->int_pin);
             }
-            writeSerial("Touch[" + String(i) + "]: kept post-EPD GT911 @0x" + String(rt->addr7, HEX) +
-                (rt->reg_high_first ? " BE" : " LE") + (tc->int_pin != 0xFF ? " INT+poll" : " poll"), true);
+            od_log_info("Touch[%u]: kept post-EPD GT911 @0x%02X%s%s", i, rt->addr7,
+                        rt->reg_high_first ? " BE" : " LE", tc->int_pin != 0xFF ? " INT+poll" : " poll");
             rt->last_poll_ms = millis();
             continue;
         }
         if (!touch_reinit_gt911(i, tc, rt)) {
-            writeSerial("Touch[" + String(i) + "]: init failed", true);
+            od_log_warn("Touch[%u]: init failed", i);
             continue;
         }
         {
@@ -545,14 +545,14 @@ void initTouchInput(void) {
                 xres = (uint16_t)inf[6] | ((uint16_t)inf[7] << 8);
                 yres = (uint16_t)inf[8] | ((uint16_t)inf[9] << 8);
             }
-            writeSerial("Touch[" + String(i) + "]: GT911 @0x" + String(rt->addr7, HEX) + " " + String(rh ? "BE" : "LE") +
-                        " " + String(xres) + "x" + String(yres) + (tc->int_pin != 0xFF ? " INT+poll" : " poll"), true);
+            od_log_info("Touch[%u]: GT911 @0x%02X %s %ux%u%s", i, rt->addr7, rh ? "BE" : "LE",
+                        xres, yres, tc->int_pin != 0xFF ? " INT+poll" : " poll");
         }
 #if TOUCH_DEBUG
         if (tc->int_pin != 0xFF && rt->int_irq_attached) {
-            writeSerial("Touch[" + String(i) + "]: INT GPIO " + String(tc->int_pin) + " FALLING", true);
+            od_log_debug("Touch[%u]: INT GPIO %u FALLING", i, tc->int_pin);
         } else if (tc->int_pin != 0xFF) {
-            writeSerial("Touch[" + String(i) + "]: INT attach failed — polling only", true);
+            od_log_debug("Touch[%u]: INT attach failed — polling only", i);
         }
 #endif
         rt->last_poll_ms = millis();
@@ -638,7 +638,7 @@ void processTouchInput(void) {
             if (rt->i2c_fail_streak >= TOUCH_I2C_FAIL_DISABLE_THRESHOLD) {
                 touch_disable_controller(i, tc, rt, "too many I2C read failures");
             } else if (rt->i2c_fail_streak == 1) {
-                writeSerial("Touch[" + String(i) + "]: I2C read fail (status reg 0x814E, addr 0x" + String(rt->addr7, HEX) + ")", true);
+                od_log_warn("Touch[%u]: I2C read fail (status reg 0x814E, addr 0x%02X)", i, rt->addr7);
             }
             rt->last_poll_ms = now;
             continue;
@@ -718,11 +718,10 @@ void processTouchInput(void) {
         if (changed) {
 #if TOUCH_DEBUG
             if (n == 0) {
-                writeSerial("Touch[" + String(i) + "]: release (MSD low nibble 6, last xy kept)", true);
+                od_log_debug("Touch[%u]: release (MSD low nibble 6, last xy kept)", i);
             } else {
                 const char* src = irq_mode ? (from_irq ? "irq" : (line_low ? "line" : "poll")) : "poll";
-                writeSerial("Touch[" + String(i) + "]: n=" + String(n) + " id=" + String(tid) + " (" + String(x) + "," + String(y) + ") st=0x" +
-                                String(st, HEX) + " " + String(src), true);
+                od_log_debug("Touch[%u]: n=%u id=%u (%u,%u) st=0x%02X %s", i, n, tid, x, y, st, src);
             }
 #endif
             updatemsdata();

--- a/src/wake_button.cpp
+++ b/src/wake_button.cpp
@@ -10,6 +10,7 @@
 #include "driver/rtc_io.h"  // RTC pull retention for ext0/ext1 pads
 #endif
 #include "structs.h"
+#include "od_log.h"
 
 #ifndef DEVICE_FLAG_BATTERY_LATCH
 #define DEVICE_FLAG_BATTERY_LATCH (1 << 3)
@@ -21,7 +22,6 @@
 extern struct GlobalConfig globalConfig;
 extern ButtonState buttonStates[MAX_BUTTONS];
 extern uint8_t buttonStateCount;
-void writeSerial(String message, bool newLine = true);
 
 // There is no ext0 status register, so the armed pin is remembered across the
 // sleep for detectButtonWake() to name. 0xFF = ext0 not armed this cycle.
@@ -38,18 +38,6 @@ struct WakeCandidate {
     bool pulldown;
 };
 
-String maskToHex(uint64_t mask) {
-    String s = "";
-    bool started = false;
-    for (int shift = 60; shift >= 0; shift -= 4) {
-        uint8_t nib = (mask >> shift) & 0xF;
-        if (!started && nib == 0 && shift != 0) continue;
-        started = true;
-        s += (char)(nib < 10 ? ('0' + nib) : ('A' + nib - 10));
-    }
-    return s;
-}
-
 #if !SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP && SOC_PM_SUPPORT_EXT1_WAKEUP
 // With RTC_PERIPH powered down, IDF maintains pulls configured through the RTC
 // IO registers via the HOLD feature — the digital-domain pinMode pulls do not
@@ -64,14 +52,14 @@ void retainWakePull(const WakeCandidate& c) {
         rtc_gpio_pulldown_en(gpio);
         rtc_gpio_pullup_dis(gpio);
     } else {
-        writeSerial("Wake: pin " + String(c.pin) + " has no internal pull - floating wake pin may cause spurious wakes");
+        od_log_warn("Wake: pin %u has no internal pull - floating wake pin may cause spurious wakes", c.pin);
     }
 }
 
 void warnUnarmedPins(uint64_t mask, const char* reason) {
     for (uint8_t pin = 0; pin < 64; pin++) {
         if (mask & (1ULL << pin)) {
-            writeSerial("Wake: pin " + String(pin) + " not armed (" + String(reason) + ") - timer-only for this button");
+            od_log_warn("Wake: pin %u not armed (%s) - timer-only for this button", pin, reason);
         }
     }
 }
@@ -81,7 +69,7 @@ void warnUnarmedPins(uint64_t mask, const char* reason) {
 
 void armButtonWakeSources() {
     if (globalConfig.power_option.sleep_flags & OD_SLEEP_FLAG_BUTTON_WAKE_DISABLE) {
-        writeSerial("Button wake disabled (sleep_flags) - timer-only deep sleep");
+        od_log_info("Button wake disabled (sleep_flags) - timer-only deep sleep");
         return;
     }
     const uint8_t deviceFlags = globalConfig.system_config.device_flags;
@@ -121,23 +109,23 @@ void armButtonWakeSources() {
         if (validPin(pwrPin2) && c.pin == pwrPin2) {
             // pwr_pin_2 is the latch hold pin (MOSFET enable / D-FF D input);
             // it is an output, never a wake button.
-            writeSerial("Wake: pin " + String(c.pin) + " is the power latch pin - not armed");
+            od_log_debug("Wake: pin %u is the power latch pin - not armed", c.pin);
             continue;
         }
         if ((deviceFlags & DEVICE_FLAG_PWR_LATCH_DFF) && validPin(pwrPin3) && c.pin == pwrPin3) {
             // On D-FF boards pwr_pin_3 is the 74AHC1G79 CP clock: a wake-armed
             // pull or level change could clock the latch off and cut power.
-            writeSerial("Wake: pin " + String(c.pin) + " is the D-FF latch clock - not armed");
+            od_log_debug("Wake: pin %u is the D-FF latch clock - not armed", c.pin);
             continue;
         }
         if (!esp_sleep_is_valid_wakeup_gpio((gpio_num_t)c.pin)) {
-            writeSerial("Wake: pin " + String(c.pin) + " not wake-capable on this chip - timer-only for this button");
+            od_log_debug("Wake: pin %u not wake-capable on this chip - timer-only for this button", c.pin);
             continue;
         }
         if (digitalRead(c.pin) == (c.wakeHigh ? HIGH : LOW)) {
             // Already at its wake level: arming would wake instantly and
             // ping-pong. The pin re-qualifies next sleep entry after release.
-            writeSerial("Wake: pin " + String(c.pin) + " held at sleep entry - skipped this cycle");
+            od_log_debug("Wake: pin %u held at sleep entry - skipped this cycle", c.pin);
             continue;
         }
         if (c.wakeHigh) highMask |= 1ULL << c.pin;
@@ -146,7 +134,7 @@ void armButtonWakeSources() {
     }
 
     if (lowMask == 0 && highMask == 0) {
-        writeSerial("No wake-capable buttons - timer-only deep sleep");
+        od_log_warn("No wake-capable buttons - timer-only deep sleep");
         return;
     }
 
@@ -156,9 +144,9 @@ void armButtonWakeSources() {
     if (lowMask) {
         esp_err_t err = esp_deep_sleep_enable_gpio_wakeup(lowMask, ESP_GPIO_WAKEUP_GPIO_LOW);
         if (err != ESP_OK) {
-            writeSerial("Wake: gpio LOW arm failed (err " + String(err) + ") - timer-only for mask 0x" + maskToHex(lowMask));
+            od_log_warn("Wake: gpio LOW arm failed (err %d) - timer-only for mask 0x%llX", err, (unsigned long long)lowMask);
         } else {
-            writeSerial("Wake: gpio LOW armed, mask 0x" + maskToHex(lowMask));
+            od_log_info("Wake: gpio LOW armed, mask 0x%llX", (unsigned long long)lowMask);
         }
     }
     if (highMask) {
@@ -166,9 +154,9 @@ void armButtonWakeSources() {
         // keep the LOW group and never abort the sleep.
         esp_err_t err = esp_deep_sleep_enable_gpio_wakeup(highMask, ESP_GPIO_WAKEUP_GPIO_HIGH);
         if (err != ESP_OK) {
-            writeSerial("Wake: gpio HIGH arm failed (err " + String(err) + ") - timer-only for mask 0x" + maskToHex(highMask));
+            od_log_warn("Wake: gpio HIGH arm failed (err %d) - timer-only for mask 0x%llX", err, (unsigned long long)highMask);
         } else {
-            writeSerial("Wake: gpio HIGH armed, mask 0x" + maskToHex(highMask));
+            od_log_info("Wake: gpio HIGH armed, mask 0x%llX", (unsigned long long)highMask);
         }
     }
 #elif SOC_PM_SUPPORT_EXT1_WAKEUP
@@ -179,14 +167,14 @@ void armButtonWakeSources() {
     if (highMask) {
         esp_sleep_enable_ext1_wakeup(highMask, ESP_EXT1_WAKEUP_ANY_HIGH);
         armedMask |= highMask;
-        writeSerial("Wake: ext1 ANY_HIGH armed, mask 0x" + maskToHex(highMask));
+        od_log_info("Wake: ext1 ANY_HIGH armed, mask 0x%llX", (unsigned long long)highMask);
     }
     if (lowMask) {
         const uint8_t firstLowPin = (uint8_t)__builtin_ctzll(lowMask);
         esp_sleep_enable_ext0_wakeup((gpio_num_t)firstLowPin, 0);
         s_ext0WakePin = firstLowPin;
         armedMask |= 1ULL << firstLowPin;
-        writeSerial("Wake: ext0 LOW armed on pin " + String(firstLowPin));
+        od_log_info("Wake: ext0 LOW armed on pin %u", firstLowPin);
         warnUnarmedPins(lowMask & ~(1ULL << firstLowPin), "classic ESP32 ext0 takes one LOW pin");
     }
 #else
@@ -196,26 +184,26 @@ void armButtonWakeSources() {
         if (highMask) {
             esp_sleep_enable_ext1_wakeup(highMask, ESP_EXT1_WAKEUP_ANY_HIGH);
             armedMask |= highMask;
-            writeSerial("Wake: ext1 ANY_HIGH armed, mask 0x" + maskToHex(highMask));
+            od_log_info("Wake: ext1 ANY_HIGH armed, mask 0x%llX", (unsigned long long)highMask);
         }
         if (lowMask) {
             const uint8_t firstLowPin = (uint8_t)__builtin_ctzll(lowMask);
             esp_sleep_enable_ext0_wakeup((gpio_num_t)firstLowPin, 0);
             s_ext0WakePin = firstLowPin;
             armedMask |= 1ULL << firstLowPin;
-            writeSerial("Wake: ext0 LOW armed on pin " + String(firstLowPin));
+            od_log_info("Wake: ext0 LOW armed on pin %u", firstLowPin);
             warnUnarmedPins(lowMask & ~(1ULL << firstLowPin), "ext1 taken by HIGH group, ext0 takes one pin");
         }
     } else {
         esp_sleep_enable_ext1_wakeup(lowMask, ESP_EXT1_WAKEUP_ANY_LOW);
         armedMask |= lowMask;
-        writeSerial("Wake: ext1 ANY_LOW armed, mask 0x" + maskToHex(lowMask));
+        od_log_info("Wake: ext1 ANY_LOW armed, mask 0x%llX", (unsigned long long)lowMask);
         if (highMask) {
             const uint8_t firstHighPin = (uint8_t)__builtin_ctzll(highMask);
             esp_sleep_enable_ext0_wakeup((gpio_num_t)firstHighPin, 1);
             s_ext0WakePin = firstHighPin;
             armedMask |= 1ULL << firstHighPin;
-            writeSerial("Wake: ext0 HIGH armed on pin " + String(firstHighPin));
+            od_log_info("Wake: ext0 HIGH armed on pin %u", firstHighPin);
             warnUnarmedPins(highMask & ~(1ULL << firstHighPin), "ext1 taken by LOW group, ext0 takes one pin");
         }
     }
@@ -238,24 +226,24 @@ bool detectButtonWake(int wakeupCause) {
         // hardware is absent — the default case covers them defensively.
 #if SOC_PM_SUPPORT_EXT0_WAKEUP
         case ESP_SLEEP_WAKEUP_EXT0:
-            writeSerial("Wake-up reason: EXT0 button (pin " + String(s_ext0WakePin) + ")");
+            od_log_info("Wake-up reason: EXT0 button (pin %u)", s_ext0WakePin);
             return true;
 #endif
 #if SOC_PM_SUPPORT_EXT1_WAKEUP
         case ESP_SLEEP_WAKEUP_EXT1:
-            writeSerial("Wake-up reason: EXT1 button (pin mask 0x" + maskToHex(esp_sleep_get_ext1_wakeup_status()) + ")");
+            od_log_info("Wake-up reason: EXT1 button (pin mask 0x%llX)", (unsigned long long)esp_sleep_get_ext1_wakeup_status());
             return true;
 #endif
 #if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
         case ESP_SLEEP_WAKEUP_GPIO:
-            writeSerial("Wake-up reason: GPIO button (pin mask 0x" + maskToHex(esp_sleep_get_gpio_wakeup_status()) + ")");
+            od_log_info("Wake-up reason: GPIO button (pin mask 0x%llX)", (unsigned long long)esp_sleep_get_gpio_wakeup_status());
             return true;
 #endif
         case ESP_SLEEP_WAKEUP_TIMER:
-            writeSerial("Wake-up reason: timer");
+            od_log_info("Wake-up reason: timer");
             return false;
         default:
-            writeSerial("Wake-up reason: " + String(wakeupCause) + " (not a button)");
+            od_log_info("Wake-up reason: %d (not a button)", wakeupCause);
             return false;
     }
 }

--- a/src/wifi_service.cpp
+++ b/src/wifi_service.cpp
@@ -4,6 +4,7 @@
 #include "communication.h"
 #include "encryption.h"
 #include "structs.h"
+#include "od_log.h"
 #include <Arduino.h>
 #include <ESPmDNS.h>
 #include <WiFi.h>
@@ -32,7 +33,6 @@ extern uint8_t tcpReceiveBuffer[8192];
 extern uint32_t tcpReceiveBufferPos;
 extern uint8_t msd_payload[16];
 
-void writeSerial(String message, bool newLine = true);
 String getChipIdHex();
 
 typedef void* BLEConnHandle;
@@ -73,50 +73,50 @@ void opendisplay_mdns_update_msd_txt(void) {
 static void restartLanService(void) {
     String deviceName = "OD" + getChipIdHex();
     if (!MDNS.begin(deviceName.c_str())) {
-        writeSerial("ERROR: mDNS responder failed");
+        od_log_error("ERROR: mDNS responder failed");
         return;
     }
-    writeSerial("mDNS: " + deviceName + ".local");
+    od_log_info("mDNS: %s.local", deviceName.c_str());
     MDNS.addService("opendisplay", "tcp", wifiServerPort);
-    writeSerial("mDNS: advertised _opendisplay._tcp port " + String(wifiServerPort));
+    od_log_info("mDNS: advertised _opendisplay._tcp port %u", wifiServerPort);
     opendisplay_mdns_update_msd_txt();
 }
 
 void initWiFi(bool waitForConnection) {
-    writeSerial("=== Initializing WiFi ===");
+    od_log_info("=== Initializing WiFi ===");
 
     if (!(globalConfig.system_config.communication_modes & COMM_MODE_WIFI)) {
-        writeSerial("WiFi not enabled in communication_modes, skipping");
+        od_log_info("WiFi not enabled in communication_modes, skipping");
         wifiInitialized = false;
         return;
     }
     if (!wifiConfigured) {
-        writeSerial("WiFi: system_config has WiFi mode on, but wifi_config TLV (0x26) is not in saved "
+        od_log_warn("WiFi: system_config has WiFi mode on, but wifi_config TLV (0x26) is not in saved "
                     "configuration (or failed to parse). Enable Wi-Fi in config, set SSID, and write full "
                     "config to the device.");
         wifiInitialized = false;
         return;
     }
     if (wifiSsid[0] == '\0' || strlen(wifiSsid) == 0) {
-        writeSerial("WiFi: wifi_config packet present but SSID field is empty.");
+        od_log_warn("WiFi: wifi_config packet present but SSID field is empty.");
         wifiInitialized = false;
         return;
     }
-    writeSerial("SSID: \"" + String(wifiSsid) + "\"");
+    od_log_info("SSID: \"%s\"", wifiSsid);
     WiFi.setAutoReconnect(true);
     WiFi.setTxPower(WIFI_POWER_15dBm);
     wifiSsid[32] = '\0';
     wifiPassword[32] = '\0';
-    writeSerial("Encryption type: 0x" + String(wifiEncryptionType, HEX));
+    od_log_info("Encryption type: 0x%02X", wifiEncryptionType);
     wifiConnected = false;
     wifiInitialized = true;
     WiFi.begin(wifiSsid, wifiPassword);
     WiFi.setTxPower(WIFI_POWER_15dBm);
     if (!waitForConnection) {
-        writeSerial("WiFi: STA started (non-blocking; LAN starts when associated)");
+        od_log_info("WiFi: STA started (non-blocking; LAN starts when associated)");
         return;
     }
-    writeSerial("Waiting for WiFi connection...");
+    od_log_info("Waiting for WiFi connection...");
     const int maxRetries = 3;
     const unsigned long timeoutPerRetry = 10000;
     bool connected = false;
@@ -126,9 +126,9 @@ void initWiFi(bool waitForConnection) {
         while (WiFi.status() != WL_CONNECTED && (millis() - startAttempt < timeoutPerRetry)) {
             delay(500);
             wl_status_t status = WiFi.status();
-            writeSerial("WiFi status: " + String(status));
+            od_log_debug("WiFi status: %d", status);
             if (status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL) {
-                writeSerial("Connection failed immediately (Status: " + String(status) + ")");
+                od_log_warn("Connection failed immediately (Status: %d)", status);
                 abortCurrentRetry = true;
                 break;
             }
@@ -138,7 +138,7 @@ void initWiFi(bool waitForConnection) {
             break;
         }
         if (!abortCurrentRetry) {
-            writeSerial("WiFi attempt " + String(retry + 1) + " timed out");
+            od_log_warn("WiFi attempt %d timed out", retry + 1);
         }
         if (retry < maxRetries - 1) {
             delay(2000);
@@ -146,20 +146,21 @@ void initWiFi(bool waitForConnection) {
     }
     if (WiFi.status() == WL_CONNECTED) {
         wifiConnected = true;
-        writeSerial("=== WiFi connected ===");
-        writeSerial("IP: " + WiFi.localIP().toString());
+        od_log_info("=== WiFi connected ===");
+        String ip = WiFi.localIP().toString();
+        od_log_info("IP: %s", ip.c_str());
         wifiServer.begin(wifiServerPort);
-        writeSerial("TCP server listening on port " + String(wifiServerPort));
+        od_log_info("TCP server listening on port %u", wifiServerPort);
         restartLanService();
     } else {
         wifiConnected = false;
-        writeSerial("=== WiFi connection failed ===");
+        od_log_warn("=== WiFi connection failed ===");
     }
 }
 
 void disconnectWiFiServer() {
     if (wifiClient.connected()) {
-        writeSerial("Closing LAN client");
+        od_log_info("Closing LAN client");
         clearEncryptionSession();
         wifiClient.stop();
     }
@@ -170,15 +171,16 @@ void disconnectWiFiServer() {
 void handleWiFiServer() {
     if (wifiInitialized && WiFi.status() == WL_CONNECTED && !wifiConnected) {
         wifiConnected = true;
-        writeSerial("=== WiFi connected ===");
-        writeSerial("IP: " + WiFi.localIP().toString());
+        od_log_info("=== WiFi connected ===");
+        String ip = WiFi.localIP().toString();
+        od_log_info("IP: %s", ip.c_str());
         wifiServer.begin(wifiServerPort);
-        writeSerial("TCP server listening on port " + String(wifiServerPort));
+        od_log_info("TCP server listening on port %u", wifiServerPort);
         restartLanService();
     }
     if (!wifiConnected || WiFi.status() != WL_CONNECTED) {
         if (wifiServerConnected || wifiClient.connected()) {
-            writeSerial("WiFi lost, closing LAN session");
+            od_log_warn("WiFi lost, closing LAN session");
             disconnectWiFiServer();
         }
         return;
@@ -187,7 +189,7 @@ void handleWiFiServer() {
     WiFiClient incoming = wifiServer.accept();
     if (incoming) {
         if (wifiClient.connected()) {
-            writeSerial("LAN: new client, replacing previous");
+            od_log_info("LAN: new client, replacing previous");
             clearEncryptionSession();
             wifiClient.stop();
         }
@@ -195,12 +197,13 @@ void handleWiFiServer() {
         wifiClient.setTimeout(30000);
         tcpReceiveBufferPos = 0;
         wifiServerConnected = true;
-        writeSerial("LAN client connected from " + wifiClient.remoteIP().toString());
+        String remoteIp = wifiClient.remoteIP().toString();
+        od_log_info("LAN client connected from %s", remoteIp.c_str());
     }
 
     if (!wifiServerConnected || !wifiClient.connected()) {
         if (wifiServerConnected) {
-            writeSerial("LAN client disconnected");
+            od_log_info("LAN client disconnected");
             clearEncryptionSession();
             wifiServerConnected = false;
             tcpReceiveBufferPos = 0;
@@ -217,7 +220,7 @@ void handleWiFiServer() {
         bytesToRead = (int)sizeof(tcpReceiveBuffer) - (int)tcpReceiveBufferPos;
     }
     if (bytesToRead <= 0) {
-        writeSerial("LAN RX buffer full, dropping connection");
+        od_log_warn("LAN RX buffer full, dropping connection");
         disconnectWiFiServer();
         return;
     }
@@ -229,7 +232,7 @@ void handleWiFiServer() {
     while (tcpReceiveBufferPos >= 2) {
         uint16_t flen = (uint16_t)(tcpReceiveBuffer[0] | (tcpReceiveBuffer[1] << 8));
         if (flen == 0 || flen > WIFI_LAN_MAX_PAYLOAD) {
-            writeSerial("LAN: invalid frame length, closing");
+            od_log_warn("LAN: invalid frame length, closing");
             disconnectWiFiServer();
             return;
         }
@@ -252,7 +255,7 @@ void restartWiFiLanAfterReconnect() {
     }
     disconnectWiFiServer();
     wifiServer.begin(wifiServerPort);
-    writeSerial("TCP server restarted on port " + String(wifiServerPort));
+    od_log_info("TCP server restarted on port %u", wifiServerPort);
     restartLanService();
 }
 


### PR DESCRIPTION
The old logging system has several issues.

All ~700 logging call sites go through writeSerial(). The String parameter heap-allocates on every call. ~330 of those calls also use String() concatenation, creating multiple intermediate heap allocations per log line.

od_log uses a stack buffer instead. It also adds a timestamp since boot in the form:

```
[0012.345|C47]
```

First is seconds.milliseconds since boot and C is the deep sleep count. If you log for some ours it is easier to find when an issues occured if you have the time.

The debug log level can be turned on with: `-DOD_LOG_LEVEL=OD_LOG_DEBUG` compile flag. If not set, all od_log_debug() compile to nothing.