### PR TITLE
fix(buttons): prime ADC channel before setting ladder pin attenuation

### DIFF
--- a/src/device_control.cpp
+++ b/src/device_control.cpp
@@ -165,6 +165,7 @@ static void registerAdcLadder(const struct BinaryInputs* input) {
     l->last_button_id = (uint8_t)(l->id_base & 0x07);
     l->last_press_time = 0;
     pinMode(l->pin, INPUT);
+    (void)analogRead(l->pin);
     analogSetPinAttenuation(l->pin, ADC_11db);
     adcLadderCount++;
     od_log_info("ADC ladder: pin %u n %u idBase %u byteIdx %u", l->pin, n, l->id_base, l->byte_index);


### PR DESCRIPTION
analogSetPinAttenuation() no-ops with an esp32-hal-adc 'Pin is not configured as analog channel' error unless the pin is already attached to the ADC, and attachment only happens on the first analogRead(). Do a throwaway read in registerAdcLadder() first so the ADC_11db attenuation call takes effect and the boot log stays clean.

No behavior change in practice: the core's default attenuation is also 11 dB, so ladder readings are unchanged. Verified on an XTEINK X4 (ESP32-C3): error line gone from boot, both ladders register, and button presses on both ADC pins still classify to the same ids. This is purely so someone looking at the boot logs doesn't think there is an actual problem.